### PR TITLE
refactor: move saves endpoints to dedicated router (issue #14)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -3,4 +3,3 @@ FastAPI application package for Prompt Engineering Studio.
 
 Greenfield MVP scope: keep things minimal and async-first.
 """
-

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -4,4 +4,3 @@ This package holds modular routers for the API. For now these files
 only define empty routers so we can gradually extract endpoints from
 app/main.py without changing behavior.
 """
-

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -2,4 +2,3 @@ from fastapi import APIRouter
 
 # Placeholder router for chat-related endpoints
 router = APIRouter(prefix="/api/chat", tags=["chat"])
-

--- a/backend/app/routers/models.py
+++ b/backend/app/routers/models.py
@@ -16,10 +16,14 @@ router = APIRouter(prefix="/api/models", tags=["models"])
 async def list_models(session: AsyncSession = Depends(get_session)):
     """Return available models from database."""
     rows = (
-        await session.execute(
-            select(ModelConfig).order_by(ModelConfig.provider, ModelConfig.model_id)
+        (
+            await session.execute(
+                select(ModelConfig).order_by(ModelConfig.provider, ModelConfig.model_id)
+            )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     return {"data": [r.raw or {"id": r.model_id, "name": r.model_name} for r in rows]}
 
 

--- a/backend/app/routers/optimize.py
+++ b/backend/app/routers/optimize.py
@@ -2,4 +2,3 @@ from fastapi import APIRouter
 
 # Placeholder router for prompt optimization
 router = APIRouter(prefix="/api/optimize", tags=["optimize"])
-

--- a/backend/app/routers/saves.py
+++ b/backend/app/routers/saves.py
@@ -14,12 +14,15 @@ router = APIRouter(prefix="/api/saves", tags=["saves"])
 
 # Pydantic Models
 
+
 class SaveRequest(BaseModel):
     title: str | None = None
     kind: str | None = None  # 'system','user','prompt','state'
     provider: str | None = None
     model: str | None = None
-    data: dict | None = None  # arbitrary: system_prompt, user_prompt, response, parameters, notes
+    data: dict | None = (
+        None  # arbitrary: system_prompt, user_prompt, response, parameters, notes
+    )
 
 
 class SaveResponse(BaseModel):
@@ -42,8 +45,11 @@ class SaveItem(BaseModel):
 
 # Endpoints
 
+
 @router.post("", response_model=SaveResponse)
-async def create_save(payload: SaveRequest, session: AsyncSession | None = Depends(try_get_session)):
+async def create_save(
+    payload: SaveRequest, session: AsyncSession | None = Depends(try_get_session)
+):
     if session is None:
         raise HTTPException(status_code=400, detail="DATABASE_URL not configured")
     sid = str(uuid.uuid4())
@@ -74,7 +80,11 @@ async def create_save(payload: SaveRequest, session: AsyncSession | None = Depen
 async def list_saves(session: AsyncSession | None = Depends(try_get_session)):
     if session is None:
         raise HTTPException(status_code=400, detail="DATABASE_URL not configured")
-    rows = (await session.execute(select(Snapshot).order_by(Snapshot.created_at.desc()))).scalars().all()
+    rows = (
+        (await session.execute(select(Snapshot).order_by(Snapshot.created_at.desc())))
+        .scalars()
+        .all()
+    )
     out: list[SaveItem] = []
     for r in rows:
         out.append(
@@ -94,7 +104,9 @@ async def list_saves(session: AsyncSession | None = Depends(try_get_session)):
 async def get_save(sid: str, session: AsyncSession | None = Depends(try_get_session)):
     if session is None:
         raise HTTPException(status_code=400, detail="DATABASE_URL not configured")
-    row = (await session.execute(select(Snapshot).where(Snapshot.id == sid))).scalar_one_or_none()
+    row = (
+        await session.execute(select(Snapshot).where(Snapshot.id == sid))
+    ).scalar_one_or_none()
     if not row:
         raise HTTPException(status_code=404, detail="Not found")
     return {

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,6 +53,8 @@ python-downloads = "automatic"
 [tool.ruff]
 line-length = 88
 target-version = "py313"
+
+[tool.ruff.lint]
 select = [
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings


### PR DESCRIPTION
Move saves endpoints and Pydantic models from main.py to routers/saves.py:
- POST /api/saves - Create snapshot
- GET /api/saves - List all snapshots
- GET /api/saves/{sid} - Get snapshot by ID

Moved models:
- SaveRequest
- SaveResponse
- SaveItem

Preserved:
- Database session dependency injection
- Error handling for missing snapshots (404)
- Sorting by created_at DESC
- All response shapes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)