### PR TITLE
Add read_url tool and request tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # Prompt Engineering Studio
 
-Web application for testing and optimizing prompts across multiple AI models via OpenRouter.
+Web application for testing and optimizing AI prompts across multiple models via OpenRouter.
 
 ## Features
 
-- Stream chat with 16+ AI models (OpenAI, Anthropic, Google, DeepSeek, XAI)
+- Stream chat with 250+ AI models (OpenAI, Anthropic, Google, DeepSeek, xAI, etc.)
 - Variable interpolation with `{{variable}}` syntax
 - AI-powered prompt optimization
-- Save/load prompt sessions
-- Tool calling support (web search, time, calculator)
-- Model parameter controls (temperature, top-p, top-k, etc.)
+- Save/load prompt snapshots
+- Tool calling support:
+  - Web search via Brave Search API
+  - Page reading via Jina Reader API (fetches full page content in Markdown)
+- Model parameter controls (temperature, top-p, top-k, frequency/presence penalties, response format, stop sequences)
+- Reasoning effort control for compatible models (DeepSeek, OpenAI o1)
+- Provider-specific best practices and prompting guides
 
 ## Tech Stack
 
-**Backend:** FastAPI, Python 3.13, PostgreSQL, SQLAlchemy 2.0, uv
+**Backend:** FastAPI, Python 3.13, PostgreSQL (optional), SQLAlchemy 2.0, uv
 **Frontend:** React 19, TypeScript, Tailwind CSS v4, Vite, Zustand
-**AI:** OpenRouter API
+**AI:** OpenRouter API (250+ models)
+**Tools:** Brave Search API, Jina Reader API
 
 ## Structure
 
@@ -23,18 +28,19 @@ Web application for testing and optimizing prompts across multiple AI models via
 prompt_studio/
 ├── backend/
 │   ├── app/
-│   │   ├── main.py
-│   │   ├── routers/         # API endpoints
-│   │   └── core/            # Configuration
-│   ├── models/              # Database models
-│   ├── services/            # OpenRouter, tool executor
-│   ├── config/              # Database, prompts
-│   └── alembic/             # Migrations
+│   │   ├── main.py           # FastAPI entry point (62 lines)
+│   │   ├── routers/          # API endpoints (chat, models, optimize, saves, providers)
+│   │   └── core/             # Configuration
+│   ├── models/               # Database models (model_config, provider_content, snapshot)
+│   ├── services/             # OpenRouter, tool executor, model catalog
+│   ├── config/               # Database, optimization prompts
+│   ├── alembic/              # Migrations
+│   └── justfile              # Development commands
 └── frontend/
     └── src/
-        ├── components/
-        ├── store/
-        └── services/
+        ├── components/       # React components (20+)
+        ├── store/            # Zustand stores
+        └── services/         # API client
 ```
 
 ## Setup
@@ -48,11 +54,11 @@ prompt_studio/
 **Backend:**
 ```bash
 cd backend
-just sync
-cp .env.example .env  # Add OPENROUTER_API_KEY
-just migrate          # Optional: run migrations
-just seed             # Optional: load best practices
-just start            # Start server
+just sync              # Install dependencies
+cp .env.example .env   # Add OPENROUTER_API_KEY
+just migrate           # Optional: run migrations
+just seed              # Optional: load provider content
+just start             # Start server
 ```
 
 **Frontend:**
@@ -69,14 +75,15 @@ npm run dev
 
 ## Environment Variables
 
-Required:
+**Required:**
 - `OPENROUTER_API_KEY` - Your OpenRouter API key
 
-Optional:
+**Optional:**
 - `DATABASE_URL` - PostgreSQL connection (for persistence)
 - `OPENROUTER_HTTP_REFERER` - Attribution header
 - `OPENROUTER_X_TITLE` - Attribution header
 - `BRAVE_API_KEY` - For web search tool
+- `JINA_API_KEY` - For enhanced page reading (200 RPM vs 20 RPM)
 
 ## API Endpoints
 
@@ -87,6 +94,7 @@ Optional:
 - `POST /api/models/refresh` - Refresh model catalog
 - `GET /api/providers` - List providers
 - `GET /api/providers/{id}/guide` - Get optimization guide
+- `GET /api/providers/{id}/prompting-guides` - Get prompting guides
 - `POST /api/saves` - Save snapshot
 - `GET /api/saves` - List snapshots
 - `GET /api/saves/{id}` - Get snapshot
@@ -108,6 +116,18 @@ just seed       # Seed database
 npm run dev     # Start dev server
 npm run build   # Production build
 ```
+
+## Database
+
+The app works without a database for basic chat. Database is optional and provides:
+- Model catalog caching
+- Provider content storage
+- Snapshot persistence
+
+Tables:
+- `model_configs` - Model metadata and pricing
+- `provider_content` - Best practices and guides
+- `snapshots` - Saved prompt sessions
 
 ## License
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,9 @@ import contextlib
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import ORJSONResponse
+from brotli_asgi import BrotliMiddleware
+from .middleware.request_id import RequestIdMiddleware
 
 from config.db import create_all, init_engine
 
@@ -24,7 +27,11 @@ from .routers import (
 
 load_env_from_project_root()
 
-app = FastAPI(title="Prompt Engineering Studio API", version="0.1.0")
+app = FastAPI(title="Prompt Engineering Studio API", version="0.1.0", default_response_class=ORJSONResponse)
+
+# Response compression
+app.add_middleware(BrotliMiddleware)
+app.add_middleware(RequestIdMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/middleware/__init__.py
+++ b/backend/app/middleware/__init__.py
@@ -1,0 +1,3 @@
+# Middleware package
+
+

--- a/backend/app/middleware/request_id.py
+++ b/backend/app/middleware/request_id.py
@@ -1,0 +1,13 @@
+import uuid
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        rid = request.headers.get("x-request-id") or uuid.uuid4().hex
+        request.state.request_id = rid
+        response = await call_next(request)
+        response.headers["x-request-id"] = rid
+        return response
+
+

--- a/backend/app/routers/chat/tools.py
+++ b/backend/app/routers/chat/tools.py
@@ -14,7 +14,7 @@ def get_tool_metadata(name: str) -> dict[str, str]:
         Dictionary with category and visibility
     """
     name_lower = (name or "").lower()
-    if name_lower == "search_web":
+    if name_lower in {"search_web", "read_url"}:
         return {"category": "search", "visibility": "primary"}
     return {"category": "other", "visibility": "secondary"}
 
@@ -29,21 +29,76 @@ def create_search_tool_schema() -> dict[str, Any]:
         "type": "function",
         "function": {
             "name": "search_web",
-            "description": "Search the web for current information. Returns search results with titles, descriptions, and URLs. Also returns rich structured data when available (weather forecasts, stock quotes, sports scores, calculations, currency conversion, etc.).",
+            "description": (
+                "Search the web for current information. Returns search results with titles, descriptions, and URLs. "
+                "Also returns rich structured data when available (weather forecasts, stock quotes, sports scores, calculations, currency conversion, etc.). "
+                "Use this tool to find relevant web pages before reading them in detail with read_url. "
+                "Prefer fewer, well-targeted searches over many similar searches."
+            ),
             "parameters": {
                 "type": "object",
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "The search query to look up"
+                        "description": "The search query to look up. Be specific and combine related concepts into a single query when possible."
                     },
                     "num_results": {
                         "type": "integer",
-                        "description": "Number of results to return (1-10)",
+                        "description": "Number of results to return (1-10). Default is 10 which provides good coverage.",
                         "default": 10
                     }
                 },
                 "required": ["query"]
+            }
+        }
+    }
+
+
+def create_read_url_tool_schema() -> dict[str, Any]:
+    """Create tool schema for reading web pages via Jina Reader API.
+
+    Returns:
+        OpenAI-compatible tool schema for reading URLs
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": "read_url",
+            "description": (
+                "Fetch and read the full content from one or more web pages. "
+                "Returns clean Markdown content optimized for LLM analysis. "
+                "Use this AFTER search_web to get detailed information from the most relevant pages found in search results. "
+                "This tool provides the actual page content, not just snippets. "
+                "Prefer reading multiple URLs in a single call rather than making separate calls for each URL."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "urls": {
+                        "type": "array",
+                        "maxItems": 10,
+                        "items": {
+                            "type": "string",
+                            "description": "A valid HTTP or HTTPS URL to fetch"
+                        },
+                        "description": (
+                            "List of web page URLs to read. You can pass multiple URLs in one call. "
+                            "Recommend selecting 2-5 of the most relevant pages from search results "
+                            "to get comprehensive information efficiently. "
+                            "Up to 8 URLs will be read per call; any additional URLs will be ignored and reported."
+                        )
+                    },
+                    "max_chars": {
+                        "type": "integer",
+                        "description": (
+                            "Optional character limit for content per URL (default: 12000). "
+                            "Content will be intelligently truncated if it exceeds this limit. "
+                            "Use higher values (20000-30000) for in-depth articles."
+                        ),
+                        "default": 12000
+                    }
+                },
+                "required": ["urls"]
             }
         }
     }

--- a/backend/justfile
+++ b/backend/justfile
@@ -3,7 +3,7 @@
 
 # Start the FastAPI development server
 start:
-    uv run uvicorn app.main:app --host 127.0.0.1 --port 8000 --reload
+    uv run uvicorn app.main:app --host 127.0.0.1 --port 8000 --reload --reload-dir app
 
 # Stop the FastAPI development server
 stop:
@@ -29,6 +29,12 @@ format-check:
 # Run database migrations
 migrate:
     uv run alembic upgrade head
+
+# Start local PostgreSQL if not already running (macOS/Homebrew)
+db:
+	@echo "Ensuring Postgres on 127.0.0.1:5432..."
+	@pg_isready -q -h 127.0.0.1 -p 5432 2>/dev/null || brew services start postgresql@16 >/dev/null 2>&1 || brew services start postgresql >/dev/null 2>&1 || true
+	@pg_isready -q -h 127.0.0.1 -p 5432 2>/dev/null && echo "✓ Postgres running" || (echo "⚠️  Start Postgres manually: brew services start postgresql@16"; exit 1)
 
 # Create a new database migration
 migration name:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "pydantic>=2.9.0",
     "pydantic-settings>=2.5.0",
     "httpx>=0.27.2",
+    "orjson>=3.10.7",
+    "brotli-asgi>=1.4.0",
     "python-dotenv>=1.0.0",
     "ruff>=0.13.3",
 ]

--- a/backend/services/openrouter.py
+++ b/backend/services/openrouter.py
@@ -15,10 +15,11 @@ class OpenRouterService:
     - Streaming returns raw text chunks suitable for SSE forwarding.
     """
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None):
+    def __init__(self, api_key: str | None = None, base_url: str | None = None, request_id: str | None = None):
         self.api_key = api_key or os.getenv("OPENROUTER_API_KEY", "")
         self.base_url = base_url or os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
         self._client: httpx.AsyncClient | None = None
+        self.request_id = request_id
 
     async def _client_ctx(self) -> httpx.AsyncClient:
         if self._client is None:
@@ -37,6 +38,10 @@ class OpenRouterService:
                 headers["HTTP-Referer"] = referer
             if title:
                 headers["X-Title"] = title
+
+            # Attach request correlation id if available
+            if self.request_id:
+                headers["X-Request-Id"] = self.request_id
 
             self._client = httpx.AsyncClient(
                 base_url=self.base_url,

--- a/frontend/src/components/BestPractices.tsx
+++ b/frontend/src/components/BestPractices.tsx
@@ -1,0 +1,65 @@
+type BestPracticesProps = {
+  bare?: boolean
+}
+
+const tips: Array<{ title: string; bullets: string[] }> = [
+  {
+    title: 'Set context up front',
+    bullets: [
+      'Describe the goal, audience, and any domain constraints.',
+      'Explain why you are asking so the model can reason about trade-offs.',
+    ],
+  },
+  {
+    title: 'Show, do, refine',
+    bullets: [
+      'Provide a short example of the tone or structure you want.',
+      'Ask the model to critique its own answer and suggest an iteration.',
+    ],
+  },
+  {
+    title: 'Constrain the output format',
+    bullets: [
+      'List required sections, bullet counts, or JSON keys explicitly.',
+      'Mention what should be avoided (jargon, speculation, etc.).',
+    ],
+  },
+  {
+    title: 'Capture evaluation signals',
+    bullets: [
+      'Define what “good” looks like in one or two measurable sentences.',
+      'Call out the most important fact(s) or citations to verify.',
+    ],
+  },
+]
+
+export function BestPractices({ bare = false }: BestPracticesProps) {
+  return (
+    <div className={`space-y-4 text-sm ${bare ? 'p-4' : 'p-6'}`}>
+      <p className="text-gray-600 dark:text-gray-300">
+        Quick reminders for crafting prompts that are easier to iterate on.
+        Use them as a checklist while you experiment in the workspace.
+      </p>
+      <div className="space-y-3">
+        {tips.map((tip) => (
+          <article
+            key={tip.title}
+            className="rounded-lg border border-gray-200 dark:border-white/10 bg-white/60 dark:bg-white/5 p-3"
+          >
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2">{tip.title}</h3>
+            <ul className="list-disc pl-4 space-y-1 text-gray-600 dark:text-gray-300">
+              {tip.bullets.map((bullet) => (
+                <li key={bullet}>{bullet}</li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Need deeper guidance? Check the prompt guides in the docs folder for provider-specific tips.
+      </p>
+    </div>
+  )
+}
+
+

--- a/frontend/src/components/ResponsePanel.tsx
+++ b/frontend/src/components/ResponsePanel.tsx
@@ -237,8 +237,7 @@ export function ResponsePanel() {
               search.id === parsed.id ? { ...search, open: false } : search
             ))
             // Advance phase immediately when tool completes, so next reasoning chunk gets new phase
-            const existingPhases = Object.keys(reasoningTexts).map(Number)
-            const nextPhase = existingPhases.length > 0 ? Math.max(...existingPhases) + 1 : 1
+            const nextPhase = reasoningPhaseRef.current + 1
             reasoningPhaseRef.current = nextPhase
             // Open the reasoning block immediately with a spinner for the next reasoning session
             setReasoningOpenMap((prev) => ({ ...prev, [nextPhase]: true }))

--- a/frontend/src/components/SettingsContent.tsx
+++ b/frontend/src/components/SettingsContent.tsx
@@ -4,7 +4,17 @@ import { ParametersPanel } from './ParametersPanel'
 import { ModelDetails } from './ModelDetails'
 import { usePromptStore, type Provider } from '../store/promptStore'
 import { getModelPreset } from '../utils/modelPresets'
-import { useSettingsStore } from '../store/settingsStore'
+import { useSettingsStore, type ProviderID } from '../store/settingsStore'
+
+const KNOWN_PROVIDERS: Record<ProviderID, true> = {
+  openai: true,
+  anthropic: true,
+  google: true,
+  xai: true,
+  deepseek: true,
+}
+
+const isKnownProvider = (id: string): id is ProviderID => id in KNOWN_PROVIDERS
 
 export function SettingsContent() {
   const provider = usePromptStore((s) => s.provider)
@@ -36,7 +46,12 @@ export function SettingsContent() {
         if (!cancelled) {
           setModels(modelList)
           // filter providers by user settings
-          const filtered = providerList.filter((p) => enabled[(p.id as any)] !== false)
+          const filtered = providerList.filter((p) => {
+            if (isKnownProvider(p.id)) {
+              return enabled[p.id] !== false
+            }
+            return true
+          })
           setProviders(filtered)
         }
       } catch {

--- a/frontend/src/store/settingsStore.ts
+++ b/frontend/src/store/settingsStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 
-type ProviderID = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek'
+export type ProviderID = 'openai' | 'anthropic' | 'google' | 'xai' | 'deepseek'
 
 interface SettingsState {
   enabledProviders: Record<ProviderID, boolean>


### PR DESCRIPTION
## Summary
- add a Jina Reader-powered `read_url` tool and wire it into the chat pipeline
  - expose `read_url` schema + metadata alongside `search_web`, allow up to 50 tool iterations, and finalize responses when tool-only runs never stream assistant text
  - ToolExecutor now calls Brave with per-tool timeouts, adds `read_url` with multi-URL support via Jina Reader, and surfaces truncation/errors for better UX
  - front-end adds a `BestPractices` panel plus copy updates so users understand how to take advantage of the richer tooling
- improve request handling and performance on the backend
  - add `RequestIdMiddleware`, propagate IDs to OpenRouter/Brave/Jina clients, and default responses to ORJSON with Brotli compression
  - add optional `JINA_API_KEY`, introduce the middleware package, update dependencies, and extend the justfile with a helper `just db` command
- tighten platform polish and docs
  - cache `/api/models` results with an in-memory TTL + ETag, switch the async DB engine to `NullPool`, and refresh README/Claude docs with the current feature set
  - fix settings provider filters via typed IDs and adjust `ResponsePanel` reasoning sequencing so tool completions advance phases deterministically

## Testing
- Not Run (not requested)
