### PR TITLE
Restyle app with material-inspired theme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
- 
 import { Header } from './components/Header'
 import { PromptEditor } from './components/PromptEditor'
 import { ResponsePanel } from './components/ResponsePanel'
@@ -11,21 +10,22 @@ import { UserSettingsScreen } from './components/UserSettingsScreen'
 import { HistoryPanel } from './components/HistoryPanel'
 import { PromptGuidanceModal } from './components/PromptGuidanceModal'
 import { PanelLeft, Settings2 } from 'lucide-react'
+import React from 'react'
 
 export default function App() {
   return (
     <>
-    <div className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100 antialiased font-sans use-app-font">
-      <Header />
-      <main>
-        <DesktopPushLayout />
-      </main>
-    </div>
-    <SettingsSheet />
-    <LeftDrawer />
-    <UserSettingsScreen />
-    <PromptGuidanceModal />
-    <ToastContainer />
+      <div className="app-shell">
+        <Header />
+        <main className="app-main">
+          <DesktopPushLayout />
+        </main>
+      </div>
+      <SettingsSheet />
+      <LeftDrawer />
+      <UserSettingsScreen />
+      <PromptGuidanceModal />
+      <ToastContainer />
     </>
   )
 }
@@ -39,74 +39,57 @@ function DesktopPushLayout() {
   const rightWidth = useUIStore((s) => s.rightWidth)
   const setLeftWidth = useUIStore((s) => s.setLeftWidth)
   const setRightWidth = useUIStore((s) => s.setRightWidth)
-  
+
   return (
-    <div className="hidden lg:flex gap-0 relative items-stretch">
-      {/* Left push drawer */}
-      <aside 
-        className={`relative flex-shrink-0 ${leftOpen ? 'self-stretch' : 'w-0 overflow-hidden'}`}
+    <div className="workspace" aria-label="Prompt studio workspace">
+      <aside
+        className="drawer"
         style={{ width: leftOpen ? `${leftWidth}px` : undefined, transition: leftOpen ? 'none' : 'width 300ms ease-in-out' }}
       >
         {leftOpen && (
           <>
-            <div className="h-full bg-gray-50/50 dark:bg-gray-900/50 backdrop-blur-sm border-r border-gray-200 dark:border-white/10">
-              {/* Drawer header with close button */}
-              <div className="h-10 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10 sticky top-0 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
-                <button
-                  onClick={toggleLeft}
-                  className="p-1.5 -ml-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
-                  aria-label="Close history"
-                >
+            <div className="drawer-surface">
+              <div className="drawer-header">
+                <button onClick={toggleLeft} className="md-icon-button" aria-label="Close library">
                   <PanelLeft className="h-4 w-4" />
                 </button>
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Library</span>
+                <span className="drawer-title">Library</span>
               </div>
-              {/* Drawer content */}
-              <div className="px-4 py-3">
+              <div className="drawer-body">
                 <HistoryPanel bare />
               </div>
             </div>
-            {/* Resize handle */}
             <ResizeHandle side="right" onResize={setLeftWidth} currentWidth={leftWidth} />
           </>
         )}
       </aside>
 
-      {/* Main work area with full-height divider between columns */}
-      <section className="flex-1 min-w-0 min-h-[calc(100vh-3.5rem)] flex transition-all duration-300">
-        <div className="flex-1 min-w-0 border-r border-gray-200 dark:border-white/10">
+      <section className="panel-stack">
+        <div className="panel-column">
           <PromptEditor />
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="panel-column">
           <ResponsePanel />
         </div>
       </section>
 
-      {/* Right push drawer */}
-      <aside 
-        className={`relative flex-shrink-0 ${settingsOpen ? 'self-stretch' : 'w-0 overflow-hidden'}`}
+      <aside
+        className="drawer"
         style={{ width: settingsOpen ? `${rightWidth}px` : undefined, transition: settingsOpen ? 'none' : 'width 300ms ease-in-out' }}
       >
         {settingsOpen && (
           <>
-            <div className="h-full bg-gray-50/50 dark:bg-gray-900/50 backdrop-blur-sm border-l border-gray-200 dark:border-white/10">
-              {/* Drawer header with close button */}
-              <div className="h-10 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10 sticky top-0 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Model Settings</span>
-                <button
-                  onClick={toggleRight}
-                  className="p-1.5 -mr-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
-                  aria-label="Close settings"
-                >
+            <div className="drawer-surface">
+              <div className="drawer-header">
+                <span className="drawer-title">Model settings</span>
+                <button onClick={toggleRight} className="md-icon-button" aria-label="Close settings">
                   <Settings2 className="h-4 w-4" />
                 </button>
               </div>
-              {/* Drawer content */}
-              <div className="px-6 py-4">
+              <div className="drawer-body">
                 <SettingsContent />
               </div>
             </div>
-            {/* Resize handle */}
             <ResizeHandle side="left" onResize={setRightWidth} currentWidth={rightWidth} />
           </>
         )}
@@ -141,10 +124,11 @@ function ResizeHandle({ side, onResize, currentWidth }: { side: 'left' | 'right'
 
   return (
     <div
-      className={`absolute top-0 ${side === 'right' ? 'right-0' : 'left-0'} h-full w-1 cursor-col-resize hover:bg-blue-500/50 active:bg-blue-500 group z-20`}
+      className="resize-handle"
+      style={{ [side === 'right' ? 'right' : 'left']: 0 }}
       onMouseDown={handleMouseDown}
-    >
-      <div className={`sticky top-1/2 -translate-y-1/2 ${side === 'right' ? 'right-0.5' : 'left-0.5'} w-1 h-12 bg-gray-400 dark:bg-gray-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity`} />
-    </div>
+      aria-label="Resize panel"
+      role="separator"
+    />
   )
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,34 +10,31 @@ export function Header() {
   const toggleTheme = useThemeStore((s) => s.toggleTheme)
 
   return (
-    <header className="sticky top-0 z-20 border-b border-gray-200/70 dark:border-white/10 backdrop-blur bg-white/70 dark:bg-gray-950/60">
-      <div className="h-14 flex items-center justify-between gap-3 px-4">
-        <div className="flex items-center gap-3">
+    <header className="app-header" aria-label="Application toolbar">
+      <div className="top-bar">
+        <div className="brand">
           <Logo size="md" />
-          <span className="font-semibold">Prompt Engineering Studio</span>
+          <div>
+            <div>Prompt Engineering Studio</div>
+            <div className="inline-hint">Material-inspired workspace</div>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={openPromptGuidance}
-            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-white/15 px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <BookOpen className="h-4 w-4" />
-            Prompt Guidance
+        <div className="action-group">
+          <button onClick={openPromptGuidance} className="md-button tonal">
+            <BookOpen className="icon-16" />
+            Prompt guidance
           </button>
-          <button
-            onClick={openUserSettings}
-            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-white/15 px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <SlidersHorizontal className="h-4 w-4" />
+          <button onClick={openUserSettings} className="md-button">
+            <SlidersHorizontal className="icon-16" />
             Settings
           </button>
           <button
             onClick={toggleTheme}
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-white/15 p-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
+            className="md-icon-button"
             aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
             title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
           >
-            {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            {theme === 'dark' ? <Sun className="icon-16" /> : <Moon className="icon-16" />}
           </button>
         </div>
       </div>

--- a/frontend/src/components/PromptEditor.tsx
+++ b/frontend/src/components/PromptEditor.tsx
@@ -46,7 +46,7 @@ export function PromptEditor() {
       const notes = Array.isArray(res.notes) ? res.notes : []
       const changes = Array.isArray(res.changes) ? res.changes : []
       const info = { time: Date.now(), notes, changes }
-      
+
       if (kind === 'system') {
         applySystemOptimization(systemPrompt, res.optimized, info)
         showToast('System prompt optimized', 'success')
@@ -96,173 +96,167 @@ export function PromptEditor() {
   const toggleLeft = useUIStore((s) => s.toggleLeft)
 
   return (
-    <section className="min-h-[calc(100vh-3.5rem)]">
-      <div className="h-10 border-b border-gray-200 dark:border-white/10 flex items-center justify-between px-4 sticky top-0 bg-white dark:bg-gray-950 z-10">
-        <div className="flex items-center gap-2">
+    <section className="panel">
+      <div className="panel-header">
+        <div className="panel-title">
           {!leftOpen && (
-            <button
-              onClick={toggleLeft}
-              className="p-1 -ml-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
-              aria-label="Open library"
-            >
-              <PanelLeft className="h-4 w-4" />
+            <button onClick={toggleLeft} className="md-icon-button" aria-label="Open library">
+              <PanelLeft className="icon-16" />
             </button>
           )}
-          <div className="font-medium">Prompt Editor</div>
+          <span>Prompt editor</span>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="text-xs text-gray-500 dark:text-gray-400">Estimated tokens: {estimatedTokens}</div>
-          <button onClick={reset} className="text-xs rounded-md border border-gray-300 dark:border-white/15 px-2.5 py-1 hover:bg-gray-100 dark:hover:bg-white/10">Clear</button>
+        <div className="meta-bar">
+          <span>Estimated tokens: {estimatedTokens}</span>
+          <button onClick={reset} className="md-button ghost">Clear</button>
         </div>
-      </div>
-      <div className="px-4 py-3 overflow-hidden">
-      <div className="flex items-center justify-between mb-1">
-        <label className="block text-sm text-gray-600 dark:text-gray-300">System prompt (optional)</label>
-        <div className="flex items-center gap-2">
-          {originalSystemPrompt && (
-            <button
-              type="button"
-              onClick={revertSystemPrompt}
-              className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
-              title="Revert to original"
-            >
-              <Undo2 className="h-3.5 w-3.5" />
-              Revert
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => optimizeField('system')}
-            disabled={!systemPrompt.trim() || optimizing.system}
-            className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 disabled:opacity-50 hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <Wand2 className="h-3.5 w-3.5" />
-            {optimizing.system ? 'Optimizing…' : 'Optimize'}
-          </button>
-        </div>
-      </div>
-      <AutoGrowTextarea
-        value={systemPrompt}
-        onChange={setSystemPrompt}
-        minHeight={88}
-        placeholder="You are a helpful assistant..."
-      />
-      {/* System optimization notes */}
-      <SystemOptimizationNotes />
-      <div className="flex items-center justify-between mt-4 mb-1">
-        <label className="block text-sm text-gray-600 dark:text-gray-300">User prompt</label>
-        <div className="flex items-center gap-2">
-          {originalUserPrompt && (
-            <button
-              type="button"
-              onClick={revertUserPrompt}
-              className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
-              title="Revert to original"
-            >
-              <Undo2 className="h-3.5 w-3.5" />
-              Revert
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => optimizeField('user')}
-            disabled={!userPrompt.trim() || optimizing.user}
-            className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 disabled:opacity-50 hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <Wand2 className="h-3.5 w-3.5" />
-            {optimizing.user ? 'Optimizing…' : 'Optimize'}
-          </button>
-        </div>
-      </div>
-      <AutoGrowTextarea
-        value={userPrompt}
-        onChange={setUserPrompt}
-        minHeight={160}
-        placeholder="Write a short summary about..."
-      />
-      <UserOptimizationNotes />
-
-      {/* Variables editor */}
-      <div className="mt-4">
-        {/* Full-width divider line that reaches the column edge */}
-        <div className="-mx-4 px-4">
-          <div className="h-10 flex items-center justify-between border-b border-gray-200 dark:border-white/10 mb-2">
-          <div className="flex items-center gap-2">
-            <Braces className="h-4 w-4" />
-            <div className="font-medium">Variables</div>
-            <div className="text-xs text-gray-500">Use {'{{variable}}'} in prompts</div>
-          </div>
-          <button onClick={addVariable} className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10">
-            <Plus className="h-3.5 w-3.5" />
-            Add
-          </button>
-          </div>
-        </div>
-        {variables.length === 0 ? (
-          <div className="text-xs text-gray-500 px-1">No variables yet.</div>
-        ) : (
-          <div className="space-y-2">
-            {variables.map((v, i) => (
-              <div key={i} className="grid grid-cols-12 gap-2 items-center px-1">
-                <input
-                  value={v.name}
-                  onChange={(e) => updateVariableName(i, e.target.value)}
-                  placeholder="name"
-                  className="col-span-5 text-sm rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <input
-                  value={v.value}
-                  onChange={(e) => updateVariableValue(i, e.target.value)}
-                  placeholder="value"
-                  className="col-span-6 text-sm rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <button
-                  onClick={() => removeVariable(i)}
-                  aria-label="Remove variable"
-                  className="col-span-1 text-xs rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
-                >×</button>
-              </div>
-            ))}
-          </div>
-        )}
       </div>
 
-      {/* Prompt Preview */}
-      <div className="mt-4">
-        {/* Full-width divider line that reaches the column edge */}
-        <div className="-mx-4 px-4">
-          <div className="h-10 flex items-center justify-between border-b border-gray-200 dark:border-white/10 mb-2">
-          <div className="font-medium">Prompt Preview</div>
-          <button
-            onClick={async () => {
-              const text = `System:\n${composedSystem || '(empty)'}\n\nUser:\n${composedUser || '(empty)'}\n`
-              try { await navigator.clipboard.writeText(text) } catch {}
-            }}
-            aria-label="Copy composed prompt"
-            title="Copy composed prompt"
-            className="rounded-md p-2 border border-gray-300 dark:border-white/15 hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <Copy className="h-4 w-4" />
-          </button>
-          </div>
-        </div>
-        <div className="px-0 text-[13px] leading-snug whitespace-pre-wrap text-gray-800 dark:text-gray-100">
-          {usedVars.length > 0 && (
-            <div className="mb-2 flex flex-wrap gap-1.5">
-              {usedVars.map(v => (
-                <span key={v.name} className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15 bg-white/60 dark:bg-white/5">
-                  {v.name}: {v.value || '(empty)'}
-                </span>
-              ))}
+      <div className="panel-body">
+        <div className="card surface-muted">
+          <div className="helper-row">
+            <div>
+              <div className="section-heading">System prompt</div>
+              <div className="section-subtext">Optional guardrails and personality for the model.</div>
             </div>
-          )}
-          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">System</div>
-          <pre className="rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedSystem || '(empty)'}</code></pre>
-          <div className="h-2" />
-          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">User</div>
-          <pre className="rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedUser || '(empty)'}</code></pre>
+            <div className="action-group">
+              {originalSystemPrompt && (
+                <button type="button" onClick={revertSystemPrompt} className="md-button ghost">
+                  <Undo2 className="icon-16" />
+                  Revert
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => optimizeField('system')}
+                disabled={!systemPrompt.trim() || optimizing.system}
+                className="md-button tonal"
+              >
+                <Wand2 className="icon-16" />
+                {optimizing.system ? 'Optimizing…' : 'Optimize'}
+              </button>
+            </div>
+          </div>
+          <AutoGrowTextarea
+            value={systemPrompt}
+            onChange={setSystemPrompt}
+            minHeight={100}
+            placeholder="You are a helpful assistant..."
+          />
+          <SystemOptimizationNotes />
         </div>
-      </div>
+
+        <div className="card surface-muted">
+          <div className="helper-row">
+            <div>
+              <div className="section-heading">User prompt</div>
+              <div className="section-subtext">What you want the model to do. Variables expand automatically.</div>
+            </div>
+            <div className="action-group">
+              {originalUserPrompt && (
+                <button type="button" onClick={revertUserPrompt} className="md-button ghost">
+                  <Undo2 className="icon-16" />
+                  Revert
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => optimizeField('user')}
+                disabled={!userPrompt.trim() || optimizing.user}
+                className="md-button primary"
+              >
+                <Wand2 className="icon-16" />
+                {optimizing.user ? 'Optimizing…' : 'Optimize'}
+              </button>
+            </div>
+          </div>
+          <AutoGrowTextarea
+            value={userPrompt}
+            onChange={setUserPrompt}
+            minHeight={160}
+            placeholder="Write a short summary about..."
+          />
+          <UserOptimizationNotes />
+        </div>
+
+        <details className="card" open={variables.length > 0}>
+          <summary className="helper-row">
+            <div className="panel-title" style={{ fontSize: '14px' }}>
+              <Braces className="icon-16" />
+              Variables
+              <span className="tag">Use {'{{variable}}'} in prompts</span>
+            </div>
+            <button onClick={addVariable} className="md-button ghost" type="button">
+              <Plus className="icon-16" />
+              Add
+            </button>
+          </summary>
+          <div className="card-content">
+            {variables.length === 0 ? (
+              <div className="subtle-text">No variables yet.</div>
+            ) : (
+              <div className="list-stack">
+                {variables.map((v, i) => (
+                  <div key={i} className="helper-row" style={{ gap: 10, alignItems: 'flex-start' }}>
+                    <input
+                      value={v.name}
+                      onChange={(e) => updateVariableName(i, e.target.value)}
+                      placeholder="name"
+                      className="text-field"
+                    />
+                    <input
+                      value={v.value}
+                      onChange={(e) => updateVariableValue(i, e.target.value)}
+                      placeholder="value"
+                      className="text-field"
+                    />
+                    <button
+                      onClick={() => removeVariable(i)}
+                      aria-label="Remove variable"
+                      className="md-icon-button"
+                      type="button"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </details>
+
+        <details className="card" open>
+          <summary className="helper-row">
+            <div className="panel-title" style={{ fontSize: '14px' }}>
+              Prompt preview
+            </div>
+            <button
+              onClick={async () => {
+                const text = `System:\n${composedSystem || '(empty)'}\n\nUser:\n${composedUser || '(empty)'}\n`
+                try { await navigator.clipboard.writeText(text) } catch {}
+              }}
+              aria-label="Copy composed prompt"
+              title="Copy composed prompt"
+              className="md-icon-button"
+              type="button"
+            >
+              <Copy className="icon-16" />
+            </button>
+          </summary>
+          <div className="card-content">
+            {usedVars.length > 0 && (
+              <div className="badge-row" style={{ marginBottom: 10 }}>
+                {usedVars.map(v => (
+                  <span key={v.name} className="tag">{v.name}: {v.value || '(empty)'}</span>
+                ))}
+              </div>
+            )}
+            <div className="section-subtext" style={{ textTransform: 'uppercase', letterSpacing: '0.08em' }}>System</div>
+            <pre className="text-field" style={{ whiteSpace: 'pre-wrap', minHeight: 80 }}>{composedSystem || '(empty)'}</pre>
+            <div className="section-subtext" style={{ textTransform: 'uppercase', letterSpacing: '0.08em' }}>User</div>
+            <pre className="text-field" style={{ whiteSpace: 'pre-wrap', minHeight: 120 }}>{composedUser || '(empty)'}</pre>
+          </div>
+        </details>
       </div>
     </section>
   )
@@ -287,8 +281,8 @@ function AutoGrowTextarea({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className="w-full resize-none rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 break-words overflow-hidden"
-      style={{ minHeight }}
+      className="text-field"
+      style={{ minHeight, resize: 'none' }}
       wrap="soft"
     />
   )
@@ -298,15 +292,15 @@ function SystemOptimizationNotes() {
   const info = usePromptStore((s) => s.systemOptInfo)
   if (!info) return null
   return (
-    <div className="mt-2 rounded-md border border-amber-300/40 dark:border-amber-300/20 bg-amber-50/60 dark:bg-amber-400/10 p-2">
-      <div className="text-xs font-medium text-amber-900 dark:text-amber-200">System prompt optimized</div>
+    <div className="card" style={{ background: 'var(--accent-soft)', borderColor: 'color-mix(in srgb, var(--accent) 45%, var(--border-subtle))' }}>
+      <div className="section-heading" style={{ fontSize: 13 }}>System prompt optimized</div>
       {info.changes.length > 0 && (
-        <ul className="list-disc pl-4 text-xs mt-1 space-y-0.5">
+        <ul className="subtle-text" style={{ margin: '8px 0', paddingLeft: 18 }}>
           {info.changes.slice(0, 5).map((c, i) => (<li key={i}>{c}</li>))}
         </ul>
       )}
       {info.notes.length > 0 && (
-        <div className="text-[11px] text-amber-800/80 dark:text-amber-200/80 mt-1">{info.notes.join(' ')}</div>
+        <div className="subtle-text">{info.notes.join(' ')}</div>
       )}
     </div>
   )
@@ -316,15 +310,15 @@ function UserOptimizationNotes() {
   const info = usePromptStore((s) => s.userOptInfo)
   if (!info) return null
   return (
-    <div className="mt-2 rounded-md border border-emerald-300/40 dark:border-emerald-300/20 bg-emerald-50/60 dark:bg-emerald-400/10 p-2">
-      <div className="text-xs font-medium text-emerald-900 dark:text-emerald-200">User prompt optimized</div>
+    <div className="card" style={{ background: 'color-mix(in srgb, #3fb27f 12%, transparent)', borderColor: 'color-mix(in srgb, #3fb27f 45%, var(--border-subtle))' }}>
+      <div className="section-heading" style={{ fontSize: 13 }}>User prompt optimized</div>
       {info.changes.length > 0 && (
-        <ul className="list-disc pl-4 text-xs mt-1 space-y-0.5">
+        <ul className="subtle-text" style={{ margin: '8px 0', paddingLeft: 18 }}>
           {info.changes.slice(0, 5).map((c, i) => (<li key={i}>{c}</li>))}
         </ul>
       )}
       {info.notes.length > 0 && (
-        <div className="text-[11px] text-emerald-800/80 dark:text-emerald-200/80 mt-1">{info.notes.join(' ')}</div>
+        <div className="subtle-text">{info.notes.join(' ')}</div>
       )}
     </div>
   )

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -4,18 +4,12 @@ export function ToastContainer() {
   const toasts = useToastStore((s) => s.toasts)
   const remove = useToastStore((s) => s.remove)
   return (
-    <div className="fixed bottom-4 right-4 z-50 space-y-2">
+    <div className="toast-container">
       {toasts.map((t) => (
         <div
           key={t.id}
           role="status"
-          className={[
-            'min-w-[220px] max-w-[360px] rounded-md shadow border px-3 py-2 text-sm',
-            'backdrop-blur bg-white/80 dark:bg-gray-900/80',
-            t.type === 'success' ? 'border-emerald-300 text-emerald-900 dark:text-emerald-200' : '',
-            t.type === 'error' ? 'border-rose-300 text-rose-900 dark:text-rose-200' : '',
-            t.type === 'info' ? 'border-blue-300 text-blue-900 dark:text-blue-200' : '',
-          ].join(' ')}
+          className={`toast ${t.type ?? 'info'}`}
           onClick={() => remove(t.id)}
         >
           {t.message}
@@ -24,4 +18,3 @@ export function ToastContainer() {
     </div>
   )
 }
-

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,168 +1,576 @@
-@import "tailwindcss";
-
-/* Configure Tailwind v4 to use class-based dark mode ONLY */
-@variant dark (&:is(.dark *));
-
-/* App base styles can go here if needed later */
-
-.use-app-font {
-  font-family: var(--app-font), ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Noto Sans, "Apple Color Emoji", "Segoe UI Emoji";
+:root {
+  --surface: #ffffff;
+  --surface-strong: #f6f7fb;
+  --surface-elevated: #ffffff;
+  --border-subtle: #d9deeb;
+  --text-primary: #1d1f2a;
+  --text-secondary: #4a4f63;
+  --text-muted: #6d7285;
+  --accent: #3b6af5;
+  --accent-strong: #1e4fd6;
+  --accent-soft: #e6ecff;
+  --danger: #d64545;
+  --shadow-soft: 0 10px 30px rgba(0,0,0,0.06);
+  --shadow-strong: 0 12px 42px rgba(26,35,126,0.18);
+  --panel-radius: 18px;
+  --input-radius: 12px;
+  --backdrop: radial-gradient(circle at 10% 20%, rgba(59,106,245,0.06), transparent 35%),
+              radial-gradient(circle at 90% 10%, rgba(255,123,0,0.05), transparent 30%),
+              radial-gradient(circle at 10% 90%, rgba(21,182,156,0.06), transparent 30%),
+              #eef0f7;
 }
 
-/* Enhanced markdown/prose styling for better readability */
+.dark {
+  --surface: #0f111a;
+  --surface-strong: #0a0c14;
+  --surface-elevated: #151826;
+  --border-subtle: #262c3f;
+  --text-primary: #eef1fb;
+  --text-secondary: #c7cbe0;
+  --text-muted: #8b90a3;
+  --accent: #7da2ff;
+  --accent-strong: #4a74f0;
+  --accent-soft: rgba(77,120,255,0.08);
+  --danger: #ff7b7b;
+  --shadow-soft: 0 12px 30px rgba(0,0,0,0.35);
+  --shadow-strong: 0 18px 50px rgba(0,0,0,0.55);
+  --backdrop: radial-gradient(circle at 15% 20%, rgba(77,120,255,0.12), transparent 32%),
+              radial-gradient(circle at 80% 0%, rgba(255,148,77,0.1), transparent 30%),
+              radial-gradient(circle at 20% 95%, rgba(38,202,170,0.1), transparent 30%),
+              #070912;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Inter", "Roboto", system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--backdrop);
+  color: var(--text-primary);
+  min-height: 100vh;
+  letter-spacing: -0.01em;
+  transition: background 240ms ease, color 240ms ease;
+}
+
+#root { min-height: 100vh; }
+
+/* Lightweight utility bridge (replaces Tailwind with Material-flavored tokens) */
+[class*="flex"] { display: flex; }
+[class*="grid"] { display: grid; }
+[class*="items-center"] { align-items: center; }
+[class*="items-start"] { align-items: flex-start; }
+[class*="items-end"] { align-items: flex-end; }
+[class*="justify-between"] { justify-content: space-between; }
+[class*="justify-center"] { justify-content: center; }
+[class*="gap-1"] { gap: 6px; }
+[class*="gap-1.5"], [class*="gap-1.5 "] { gap: 6px; }
+[class*="gap-2"] { gap: 8px; }
+[class*="gap-3"] { gap: 12px; }
+[class*="gap-4"] { gap: 16px; }
+[class*="px-4"] { padding-left: 16px; padding-right: 16px; }
+[class*="px-6"] { padding-left: 20px; padding-right: 20px; }
+[class*="px-2.5"] { padding-left: 10px; padding-right: 10px; }
+[class*="px-2"] { padding-left: 8px; padding-right: 8px; }
+[class*="py-3"] { padding-top: 12px; padding-bottom: 12px; }
+[class*="py-1.5"] { padding-top: 6px; padding-bottom: 6px; }
+[class*="py-1"] { padding-top: 4px; padding-bottom: 4px; }
+[class*="py-4"] { padding-top: 16px; padding-bottom: 16px; }
+[class*="p-2"] { padding: 8px; }
+[class*="p-3"] { padding: 12px; }
+[class*="p-4"] { padding: 16px; }
+[class*="p-6"] { padding: 20px; }
+[class*="mt-2"] { margin-top: 8px; }
+[class*="mt-4"] { margin-top: 16px; }
+[class*="mt-6"] { margin-top: 24px; }
+[class*="mb-1"] { margin-bottom: 4px; }
+[class*="mb-2"] { margin-bottom: 8px; }
+[class*="mb-3"] { margin-bottom: 12px; }
+[class*="mb-4"] { margin-bottom: 16px; }
+[class*="mx-4"] { margin-left: 16px; margin-right: 16px; }
+[class*="-mx-4"] { margin-left: -16px; margin-right: -16px; }
+[class*="-ml-1"] { margin-left: -4px; }
+[class*="-ml-1.5"] { margin-left: -6px; }
+[class*="-mr-1.5"] { margin-right: -6px; }
+[class*="h-10"] { height: 40px; }
+[class*="h-12"] { height: 48px; }
+[class*="h-4"] { height: 16px; }
+[class*="w-4"] { width: 16px; }
+[class*="h-3.5"] { height: 14px; }
+[class*="w-3.5"] { width: 14px; }
+[class*="h-3"] { height: 12px; }
+[class*="w-3"] { width: 12px; }
+[class*="h-full"] { height: 100%; }
+[class*="w-full"] { width: 100%; }
+[class*="w-0"] { width: 0; }
+[class*="w-[min(92vw,480px)]"] { width: min(92vw, 480px); }
+[class*="min-h-[calc(100vh-3.5rem)]"] { min-height: calc(100vh - 3.5rem); }
+[class*="min-w-0"] { min-width: 0; }
+[class*="flex-1"] { flex: 1; }
+[class*="font-medium"] { font-weight: 600; }
+[class*="font-semibold"] { font-weight: 700; }
+[class*="text-xs"] { font-size: 12px; }
+[class*="text-sm"] { font-size: 14px; }
+[class*="text-[13px]"] { font-size: 13px; }
+[class*="text-[11px]"] { font-size: 11px; }
+[class*="text-gray-500"], [class*="text-gray-400"], [class*="text-gray-600"] { color: var(--text-muted); }
+[class*="text-gray-800"], [class*="text-gray-900"] { color: var(--text-primary); }
+[class*="text-blue-600"] { color: var(--accent-strong); }
+[class*="bg-white"] { background: var(--surface); }
+[class*="bg-white/50"] { background: color-mix(in srgb, var(--surface) 80%, transparent); }
+[class*="bg-gray-50"] { background: color-mix(in srgb, var(--surface) 94%, transparent); }
+[class*="bg-gray-700"] { background: #303a52; color: #fff; }
+[class*="bg-emerald-600"] { background: #22c55e; color: #fff; }
+[class*="hover:bg-gray-100"]:hover { background: color-mix(in srgb, var(--surface) 88%, transparent); }
+[class*="cursor-pointer"] { cursor: pointer; }
+[class*="backdrop-blur"] { backdrop-filter: blur(12px); }
+[class*="rounded-md"] { border-radius: 12px; }
+[class*="rounded-xl"] { border-radius: 18px; }
+[class*="border"] { border: 1px solid var(--border-subtle); }
+[class*="border-l"] { border-left: 1px solid var(--border-subtle); }
+[class*="border-r"] { border-right: 1px solid var(--border-subtle); }
+[class*="border-b"] { border-bottom: 1px solid var(--border-subtle); }
+[class*="border-t"] { border-top: 1px solid var(--border-subtle); }
+[class*="shadow"] { box-shadow: var(--shadow-soft); }
+[class*="sticky"] { position: sticky; }
+[class*="top-0"] { top: 0; }
+[class*="overflow-hidden"] { overflow: hidden; }
+[class*="overflow-auto"] { overflow: auto; }
+[class*="overflow-y-auto"] { overflow-y: auto; }
+[class*="leading-snug"] { line-height: 1.35; }
+[class*="uppercase"] { text-transform: uppercase; }
+[class*="text-center"] { text-align: center; }
+
+.dark [class*="bg-gray-900"], .dark [class*="bg-gray-950"] { background: var(--surface-strong); }
+.dark [class*="text-gray-300"], .dark [class*="text-gray-400"], .dark [class*="text-gray-500"], .dark [class*="text-gray-600"] { color: var(--text-muted); }
+.dark [class*="border-white/10"], .dark [class*="border-white/15"] { border-color: var(--border-subtle); }
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(145deg, transparent, rgba(0,0,0,0.02)), var(--backdrop);
+}
+
+.app-main { flex: 1; }
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(14px);
+  background: color-mix(in srgb, var(--surface) 85%, transparent);
+  border-bottom: 1px solid var(--border-subtle);
+  box-shadow: 0 1px 0 rgba(0,0,0,0.02);
+}
+
+.top-bar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 18px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.action-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.md-button {
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 600;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.md-button:hover { transform: translateY(-1px); box-shadow: var(--shadow-soft); }
+.md-button:active { transform: translateY(0); }
+
+.md-button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: var(--shadow-strong);
+}
+
+.md-button.tonal {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border-color: transparent;
+}
+
+.md-button.ghost {
+  background: transparent;
+  box-shadow: none;
+}
+
+.md-icon-button {
+  height: 40px;
+  width: 40px;
+  min-width: 40px;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-elevated);
+  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.md-icon-button:hover { box-shadow: var(--shadow-soft); }
+
+.workspace {
+  display: none;
+  position: relative;
+  gap: 0;
+}
+
+@media (min-width: 1024px) {
+  .workspace { display: flex; }
+}
+
+.drawer {
+  position: relative;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.drawer-surface {
+  height: 100%;
+  background: var(--surface);
+  border-inline: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.drawer-header {
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.drawer-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.drawer-body { padding: 16px 14px 18px; overflow: auto; flex: 1; }
+
+.resize-handle {
+  position: absolute;
+  top: 0;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.resize-handle::after {
+  content: '';
+  width: 3px;
+  height: 38px;
+  border-radius: 999px;
+  background: var(--border-subtle);
+  opacity: 0.6;
+  transition: background 180ms ease, opacity 180ms ease, width 140ms ease;
+}
+
+.resize-handle:hover::after { opacity: 1; width: 4px; background: var(--accent-strong); }
+
+.panel-stack {
+  display: flex;
+  min-height: calc(100vh - 56px);
+  flex: 1;
+  transition: width 300ms ease;
+}
+
+.panel-column {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.panel-column:last-of-type { border-right: none; }
+
+.panel { flex: 1; display: flex; flex-direction: column; }
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--surface) 95%, transparent);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+
+.panel-title {
+  font-weight: 700;
+  font-size: 15px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.panel-body {
+  padding: 18px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.section-heading { font-size: 14px; font-weight: 700; color: var(--text-primary); }
+.section-subtext { font-size: 13px; color: var(--text-muted); }
+
+.card {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--panel-radius);
+  padding: 14px 16px;
+  box-shadow: var(--shadow-soft);
+}
+
+details.card {
+  padding: 0;
+  overflow: hidden;
+}
+
+details.card summary {
+  padding: 14px 16px;
+  list-style: none;
+  cursor: pointer;
+}
+
+details.card summary::-webkit-details-marker { display: none; }
+details.card[open] summary { border-bottom: 1px solid var(--border-subtle); }
+
+.card-content {
+  padding: 12px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.surface-muted { background: color-mix(in srgb, var(--surface) 96%, transparent); }
+
+.meta-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.text-field {
+  width: 100%;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  color: var(--text-primary);
+  border-radius: var(--input-radius);
+  padding: 12px 14px;
+  font-size: 15px;
+  line-height: 1.5;
+  resize: vertical;
+  transition: border-color 140ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.text-field:focus {
+  outline: none;
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+input.text-field, select.text-field { height: 44px; padding: 10px 12px; }
+
+.helper-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.helper-row .md-button { padding: 8px 12px; font-size: 13px; }
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.subtle-text { color: var(--text-muted); font-size: 13px; }
+
+.divider {
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+  margin: 4px 0 2px;
+}
+
+.list-stack { display: flex; flex-direction: column; gap: 12px; }
+
+.list-card {
+  width: 100%;
+  text-align: left;
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 180ms ease, border-color 160ms ease;
+}
+
+.list-card:hover { transform: translateY(-1px); box-shadow: var(--shadow-soft); border-color: color-mix(in srgb, var(--accent) 38%, var(--border-subtle)); }
+
+.list-card .title { font-size: 14px; font-weight: 700; color: var(--text-primary); margin-bottom: 6px; }
+
+.list-card .meta { font-size: 12px; color: var(--text-muted); display: flex; gap: 8px; flex-wrap: wrap; }
+
+.toast-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 50;
+}
+
+.toast {
+  background: var(--surface-elevated);
+  border: 1px solid var(--border-subtle);
+  padding: 12px 14px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-soft);
+  min-width: 220px;
+  color: var(--text-primary);
+}
+
+.toast.success { border-color: color-mix(in srgb, #3fb27f 50%, var(--border-subtle)); }
+.toast.error { border-color: color-mix(in srgb, #d64545 60%, var(--border-subtle)); }
+
+.mobile-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(0,0,0,0.35);
+  backdrop-filter: blur(8px);
+}
+
+.mobile-sheet .sheet-panel {
+  background: var(--surface);
+  width: min(92vw, 480px);
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-strong);
+}
+
+.sheet-header {
+  height: 52px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.modal-surface {
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-strong);
+  padding: 20px;
+}
+
 .prose {
-  color: #1f2937;
-
-  /* Paragraph spacing */
-  p {
-    margin-top: 1em;
-    margin-bottom: 1em;
-  }
-
-  /* First paragraph no top margin */
-  > :first-child {
-    margin-top: 0;
-  }
-
-  /* Last element no bottom margin */
-  > :last-child {
-    margin-bottom: 0;
-  }
-
-  /* Heading spacing */
-  h1, h2, h3, h4, h5, h6 {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    font-weight: 600;
-    line-height: 1.3;
-  }
-
-  h1 { font-size: 1.5em; }
-  h2 { font-size: 1.3em; }
-  h3 { font-size: 1.15em; }
-
-  /* List spacing */
-  ul, ol {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1.5em;
-  }
-
-  li {
-    margin-top: 0.25em;
-    margin-bottom: 0.25em;
-  }
-
-  /* Code blocks */
-  pre {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding: 1em;
-    border-radius: 0.5em;
-    overflow-wrap: break-word;
-    white-space: pre-wrap;
-    word-break: break-word;
-    background-color: #1f2937 !important;
-    color: #e5e7eb;
-  }
-
-  /* Inline code */
-  code {
-    padding: 0.2em 0.4em;
-    border-radius: 0.25em;
-    font-size: 0.9em;
-    background-color: #1f2937 !important;
-    color: #e5e7eb;
-    word-break: break-word;
-  }
-
-  /* Code inside pre shouldn't have double background */
-  pre code {
-    padding: 0;
-    background-color: transparent !important;
-    color: inherit;
-  }
-
-  /* Blockquotes */
-  blockquote {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1em;
-    border-left: 3px solid #d1d5db;
-    font-style: italic;
-    color: #6b7280;
-  }
-
-  /* Tables */
-  table {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  th, td {
-    padding: 0.5em;
-    border: 1px solid #e5e7eb;
-  }
-
-  th {
-    background-color: #f9fafb;
-    font-weight: 600;
-  }
-
-  /* Links */
-  a {
-    color: rgb(37 99 235);
-    text-decoration: underline;
-  }
-
-  /* Horizontal rules */
-  hr {
-    margin-top: 1.5em;
-    margin-bottom: 1.5em;
-    border-color: #e5e7eb;
-  }
+  color: var(--text-primary);
+  line-height: 1.65;
+  font-size: 15px;
 }
 
-/* Dark mode overrides for prose */
-.dark .prose {
-  color: #e5e7eb;
+.prose p { margin: 0 0 14px; }
+.prose h2, .prose h3, .prose h4 { margin: 18px 0 10px; font-weight: 700; color: var(--text-primary); }
+.prose ul { padding-left: 20px; margin: 10px 0; }
+.prose li { margin-bottom: 8px; }
+.prose code { background: color-mix(in srgb, var(--text-primary) 6%, transparent); padding: 3px 6px; border-radius: 6px; }
+.prose pre { background: #0f172a; color: #e5e7eb; padding: 12px; border-radius: 12px; overflow: auto; }
 
-  pre {
-    background-color: #0a0c10 !important;
-    color: #e5e7eb;
-  }
+.dark .prose pre { background: #05070f; }
 
-  code {
-    background-color: #0a0c10 !important;
-    color: #e5e7eb;
-  }
+.badge-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 
-  pre code {
-    background-color: transparent !important;
-    color: inherit;
-  }
+.inline-hint { font-size: 12px; color: var(--text-muted); }
 
-  blockquote {
-    border-left-color: rgba(255, 255, 255, 0.2);
-    color: #9ca3af;
-  }
+hr { border: none; border-top: 1px solid var(--border-subtle); }
 
-  th, td {
-    border-color: rgba(255, 255, 255, 0.1);
-  }
+.icon-14 { width: 14px; height: 14px; }
+.icon-16 { width: 16px; height: 16px; }
+.icon-18 { width: 18px; height: 18px; }
 
-  th {
-    background-color: rgba(255, 255, 255, 0.05);
-  }
-
-  a {
-    color: rgb(96 165 250);
-  }
-
-  hr {
-    border-color: rgba(255, 255, 255, 0.1);
-  }
-}
-
+::-webkit-scrollbar { width: 12px; height: 12px; }
+::-webkit-scrollbar-thumb { background: color-mix(in srgb, var(--text-muted) 40%, transparent); border-radius: 8px; border: 3px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-track { background: transparent; }
+[class*="rounded-full"] { border-radius: 999px; }
+[class*="rounded-lg"] { border-radius: 14px; }
+[class*="bg-white/5"] { background: color-mix(in srgb, var(--surface) 95%, transparent); }
+[class*="bg-white/10"] { background: color-mix(in srgb, var(--surface) 90%, transparent); }
+[class*="bg-white/80"] { background: color-mix(in srgb, var(--surface) 90%, transparent); }
+[class*="bg-white/70"] { background: color-mix(in srgb, var(--surface) 80%, transparent); }
+[class*="bg-white/60"] { background: color-mix(in srgb, var(--surface) 70%, transparent); }
+[class*="bg-amber-50"] { background: #fef3c7; }
+[class*="bg-amber-400/10"] { background: rgba(251, 191, 36, 0.12); }
+[class*="bg-emerald-50"] { background: #ecfdf3; }
+[class*="bg-emerald-400/10"] { background: rgba(52, 211, 153, 0.12); }
+[class*="text-emerald-900"], [class*="text-amber-900"] { color: var(--text-primary); }
+[class*="shadow-sm"] { box-shadow: 0 1px 8px rgba(0,0,0,0.06); }
+[class*="space-y-3"] > :not(:last-child) { margin-bottom: 12px; }
+[class*="space-y-2"] > :not(:last-child) { margin-bottom: 8px; }
+[class*="space-y-4"] > :not(:last-child) { margin-bottom: 16px; }
+[class*="leading-snug"] { line-height: 1.4; }


### PR DESCRIPTION
## Summary
- replace Tailwind import with material-inspired design tokens and utility bridge
- restyle header, prompt editor, and toast components for the new look and progressive disclosure
- keep light/dark theming while modernizing layouts and surface styling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692004bff014832b9770bfd07b32673d)