### PR TITLE
Restyle UI with material theme without tailwind

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,9 +15,9 @@ import { PanelLeft, Settings2 } from 'lucide-react'
 export default function App() {
   return (
     <>
-    <div className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100 antialiased font-sans use-app-font">
+    <div className="app-shell">
       <Header />
-      <main>
+      <main className="workspace" aria-label="Prompt Studio workspace">
         <DesktopPushLayout />
       </main>
     </div>
@@ -39,30 +39,28 @@ function DesktopPushLayout() {
   const rightWidth = useUIStore((s) => s.rightWidth)
   const setLeftWidth = useUIStore((s) => s.setLeftWidth)
   const setRightWidth = useUIStore((s) => s.setRightWidth)
-  
+
   return (
-    <div className="hidden lg:flex gap-0 relative items-stretch">
+    <div className="layout-grid">
       {/* Left push drawer */}
-      <aside 
-        className={`relative flex-shrink-0 ${leftOpen ? 'self-stretch' : 'w-0 overflow-hidden'}`}
-        style={{ width: leftOpen ? `${leftWidth}px` : undefined, transition: leftOpen ? 'none' : 'width 300ms ease-in-out' }}
+      <aside
+        className={`drawer ${leftOpen ? 'drawer-open' : 'drawer-closed'}`}
+        style={{ width: leftOpen ? `${leftWidth}px` : undefined, transition: leftOpen ? 'none' : 'width 280ms ease-in-out' }}
       >
         {leftOpen && (
           <>
-            <div className="h-full bg-gray-50/50 dark:bg-gray-900/50 backdrop-blur-sm border-r border-gray-200 dark:border-white/10">
-              {/* Drawer header with close button */}
-              <div className="h-10 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10 sticky top-0 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
+            <div className="drawer-surface" aria-label="History drawer">
+              <div className="drawer-header">
                 <button
                   onClick={toggleLeft}
-                  className="p-1.5 -ml-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
+                  className="icon-button"
                   aria-label="Close history"
                 >
-                  <PanelLeft className="h-4 w-4" />
+                  <PanelLeft className="icon" />
                 </button>
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Library</span>
+                <span className="label">Library</span>
               </div>
-              {/* Drawer content */}
-              <div className="px-4 py-3">
+              <div className="drawer-content">
                 <HistoryPanel bare />
               </div>
             </div>
@@ -73,36 +71,34 @@ function DesktopPushLayout() {
       </aside>
 
       {/* Main work area with full-height divider between columns */}
-      <section className="flex-1 min-w-0 min-h-[calc(100vh-3.5rem)] flex transition-all duration-300">
-        <div className="flex-1 min-w-0 border-r border-gray-200 dark:border-white/10">
+      <section className="canvas">
+        <div className="panel">
           <PromptEditor />
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="panel">
           <ResponsePanel />
         </div>
       </section>
 
       {/* Right push drawer */}
-      <aside 
-        className={`relative flex-shrink-0 ${settingsOpen ? 'self-stretch' : 'w-0 overflow-hidden'}`}
-        style={{ width: settingsOpen ? `${rightWidth}px` : undefined, transition: settingsOpen ? 'none' : 'width 300ms ease-in-out' }}
+      <aside
+        className={`drawer ${settingsOpen ? 'drawer-open' : 'drawer-closed'}`}
+        style={{ width: settingsOpen ? `${rightWidth}px` : undefined, transition: settingsOpen ? 'none' : 'width 280ms ease-in-out' }}
       >
         {settingsOpen && (
           <>
-            <div className="h-full bg-gray-50/50 dark:bg-gray-900/50 backdrop-blur-sm border-l border-gray-200 dark:border-white/10">
-              {/* Drawer header with close button */}
-              <div className="h-10 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10 sticky top-0 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Model Settings</span>
+            <div className="drawer-surface" aria-label="Model settings">
+              <div className="drawer-header">
+                <span className="label">Model settings</span>
                 <button
                   onClick={toggleRight}
-                  className="p-1.5 -mr-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
+                  className="icon-button"
                   aria-label="Close settings"
                 >
-                  <Settings2 className="h-4 w-4" />
+                  <Settings2 className="icon" />
                 </button>
               </div>
-              {/* Drawer content */}
-              <div className="px-6 py-4">
+              <div className="drawer-content padded">
                 <SettingsContent />
               </div>
             </div>
@@ -141,10 +137,10 @@ function ResizeHandle({ side, onResize, currentWidth }: { side: 'left' | 'right'
 
   return (
     <div
-      className={`absolute top-0 ${side === 'right' ? 'right-0' : 'left-0'} h-full w-1 cursor-col-resize hover:bg-blue-500/50 active:bg-blue-500 group z-20`}
+      className={`resize-handle ${side === 'right' ? 'right-handle' : 'left-handle'}`}
       onMouseDown={handleMouseDown}
     >
-      <div className={`sticky top-1/2 -translate-y-1/2 ${side === 'right' ? 'right-0.5' : 'left-0.5'} w-1 h-12 bg-gray-400 dark:bg-gray-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity`} />
+      <div className="resize-indicator" />
     </div>
   )
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,36 +10,37 @@ export function Header() {
   const toggleTheme = useThemeStore((s) => s.toggleTheme)
 
   return (
-    <header className="sticky top-0 z-20 border-b border-gray-200/70 dark:border-white/10 backdrop-blur bg-white/70 dark:bg-gray-950/60">
-      <div className="h-14 flex items-center justify-between gap-3 px-4">
-        <div className="flex items-center gap-3">
-          <Logo size="md" />
-          <span className="font-semibold">Prompt Engineering Studio</span>
+    <header className="app-header">
+      <div className="brand">
+        <Logo size="md" />
+        <div className="brand-text">
+          <span className="title">Prompt Engineering Studio</span>
+          <span className="subtitle">Material-inspired workspace</span>
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={openPromptGuidance}
-            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-white/15 px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <BookOpen className="h-4 w-4" />
-            Prompt Guidance
-          </button>
-          <button
-            onClick={openUserSettings}
-            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-white/15 px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <SlidersHorizontal className="h-4 w-4" />
-            Settings
-          </button>
-          <button
-            onClick={toggleTheme}
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-white/15 p-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-            aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-            title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
-          >
-            {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-          </button>
-        </div>
+      </div>
+      <div className="action-bar">
+        <button
+          onClick={openPromptGuidance}
+          className="button tonal"
+        >
+          <BookOpen className="icon" />
+          Prompt guidance
+        </button>
+        <button
+          onClick={openUserSettings}
+          className="button tonal"
+        >
+          <SlidersHorizontal className="icon" />
+          Settings
+        </button>
+        <button
+          onClick={toggleTheme}
+          className="icon-button"
+          aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+          title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+        >
+          {theme === 'dark' ? <Sun className="icon" /> : <Moon className="icon" />}
+        </button>
       </div>
     </header>
   )

--- a/frontend/src/components/PromptEditor.tsx
+++ b/frontend/src/components/PromptEditor.tsx
@@ -96,37 +96,40 @@ export function PromptEditor() {
   const toggleLeft = useUIStore((s) => s.toggleLeft)
 
   return (
-    <section className="min-h-[calc(100vh-3.5rem)]">
-      <div className="h-10 border-b border-gray-200 dark:border-white/10 flex items-center justify-between px-4 sticky top-0 bg-white dark:bg-gray-950 z-10">
-        <div className="flex items-center gap-2">
+    <section className="surface-card prompt-editor">
+      <div className="section-header">
+        <div className="section-title">
           {!leftOpen && (
             <button
               onClick={toggleLeft}
-              className="p-1 -ml-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
+              className="icon-button"
               aria-label="Open library"
             >
-              <PanelLeft className="h-4 w-4" />
+              <PanelLeft className="icon" />
             </button>
           )}
-          <div className="font-medium">Prompt Editor</div>
+          <div className="title">Prompt editor</div>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="text-xs text-gray-500 dark:text-gray-400">Estimated tokens: {estimatedTokens}</div>
-          <button onClick={reset} className="text-xs rounded-md border border-gray-300 dark:border-white/15 px-2.5 py-1 hover:bg-gray-100 dark:hover:bg-white/10">Clear</button>
+        <div className="meta-row">
+          <div className="meta">Estimated tokens: {estimatedTokens}</div>
+          <button onClick={reset} className="button text">Clear</button>
         </div>
       </div>
-      <div className="px-4 py-3 overflow-hidden">
-      <div className="flex items-center justify-between mb-1">
-        <label className="block text-sm text-gray-600 dark:text-gray-300">System prompt (optional)</label>
-        <div className="flex items-center gap-2">
+      <div className="section-body">
+      <div className="section-subheader">
+        <div className="label-group">
+          <label className="label">System prompt (optional)</label>
+          <span className="helper">Set the model role and boundaries.</span>
+        </div>
+        <div className="action-group">
           {originalSystemPrompt && (
             <button
               type="button"
               onClick={revertSystemPrompt}
-              className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
+              className="button text"
               title="Revert to original"
             >
-              <Undo2 className="h-3.5 w-3.5" />
+              <Undo2 className="icon" />
               Revert
             </button>
           )}
@@ -134,9 +137,9 @@ export function PromptEditor() {
             type="button"
             onClick={() => optimizeField('system')}
             disabled={!systemPrompt.trim() || optimizing.system}
-            className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 disabled:opacity-50 hover:bg-gray-100 dark:hover:bg-white/10"
+            className="button tonal"
           >
-            <Wand2 className="h-3.5 w-3.5" />
+            <Wand2 className="icon" />
             {optimizing.system ? 'Optimizing…' : 'Optimize'}
           </button>
         </div>
@@ -149,17 +152,20 @@ export function PromptEditor() {
       />
       {/* System optimization notes */}
       <SystemOptimizationNotes />
-      <div className="flex items-center justify-between mt-4 mb-1">
-        <label className="block text-sm text-gray-600 dark:text-gray-300">User prompt</label>
-        <div className="flex items-center gap-2">
+      <div className="section-subheader">
+        <div className="label-group">
+          <label className="label">User prompt</label>
+          <span className="helper">Give the model the exact task.</span>
+        </div>
+        <div className="action-group">
           {originalUserPrompt && (
             <button
               type="button"
               onClick={revertUserPrompt}
-              className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
+              className="button text"
               title="Revert to original"
             >
-              <Undo2 className="h-3.5 w-3.5" />
+              <Undo2 className="icon" />
               Revert
             </button>
           )}
@@ -167,9 +173,9 @@ export function PromptEditor() {
             type="button"
             onClick={() => optimizeField('user')}
             disabled={!userPrompt.trim() || optimizing.user}
-            className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 disabled:opacity-50 hover:bg-gray-100 dark:hover:bg-white/10"
+            className="button tonal"
           >
-            <Wand2 className="h-3.5 w-3.5" />
+            <Wand2 className="icon" />
             {optimizing.user ? 'Optimizing…' : 'Optimize'}
           </button>
         </div>
@@ -184,42 +190,43 @@ export function PromptEditor() {
 
       {/* Variables editor */}
       <div className="mt-4">
-        {/* Full-width divider line that reaches the column edge */}
-        <div className="-mx-4 px-4">
-          <div className="h-10 flex items-center justify-between border-b border-gray-200 dark:border-white/10 mb-2">
-          <div className="flex items-center gap-2">
-            <Braces className="h-4 w-4" />
-            <div className="font-medium">Variables</div>
-            <div className="text-xs text-gray-500">Use {'{{variable}}'} in prompts</div>
+        <div className="section-divider">
+          <div className="section-subheader">
+          <div className="label-group">
+            <div className="label with-icon">
+              <Braces className="icon" />
+              Variables
+            </div>
+            <div className="helper">Use {'{{variable}}'} in prompts</div>
           </div>
-          <button onClick={addVariable} className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10">
-            <Plus className="h-3.5 w-3.5" />
+          <button onClick={addVariable} className="button tonal">
+            <Plus className="icon" />
             Add
           </button>
           </div>
         </div>
         {variables.length === 0 ? (
-          <div className="text-xs text-gray-500 px-1">No variables yet.</div>
+          <div className="empty-state">No variables yet.</div>
         ) : (
-          <div className="space-y-2">
+          <div className="variable-grid">
             {variables.map((v, i) => (
-              <div key={i} className="grid grid-cols-12 gap-2 items-center px-1">
+              <div key={i} className="variable-row">
                 <input
                   value={v.name}
                   onChange={(e) => updateVariableName(i, e.target.value)}
                   placeholder="name"
-                  className="col-span-5 text-sm rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="text-input"
                 />
                 <input
                   value={v.value}
                   onChange={(e) => updateVariableValue(i, e.target.value)}
                   placeholder="value"
-                  className="col-span-6 text-sm rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="text-input"
                 />
                 <button
                   onClick={() => removeVariable(i)}
                   aria-label="Remove variable"
-                  className="col-span-1 text-xs rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
+                  className="icon-button subtle"
                 >×</button>
               </div>
             ))}
@@ -229,10 +236,9 @@ export function PromptEditor() {
 
       {/* Prompt Preview */}
       <div className="mt-4">
-        {/* Full-width divider line that reaches the column edge */}
-        <div className="-mx-4 px-4">
-          <div className="h-10 flex items-center justify-between border-b border-gray-200 dark:border-white/10 mb-2">
-          <div className="font-medium">Prompt Preview</div>
+        <div className="section-divider">
+          <div className="section-subheader">
+          <div className="label">Prompt preview</div>
           <button
             onClick={async () => {
               const text = `System:\n${composedSystem || '(empty)'}\n\nUser:\n${composedUser || '(empty)'}\n`
@@ -240,27 +246,30 @@ export function PromptEditor() {
             }}
             aria-label="Copy composed prompt"
             title="Copy composed prompt"
-            className="rounded-md p-2 border border-gray-300 dark:border-white/15 hover:bg-gray-100 dark:hover:bg-white/10"
+            className="icon-button subtle"
           >
-            <Copy className="h-4 w-4" />
+            <Copy className="icon" />
           </button>
           </div>
         </div>
-        <div className="px-0 text-[13px] leading-snug whitespace-pre-wrap text-gray-800 dark:text-gray-100">
+        <div className="preview-block">
           {usedVars.length > 0 && (
-            <div className="mb-2 flex flex-wrap gap-1.5">
+            <div className="chip-row">
               {usedVars.map(v => (
-                <span key={v.name} className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15 bg-white/60 dark:bg-white/5">
+                <span key={v.name} className="chip">
                   {v.name}: {v.value || '(empty)'}
                 </span>
               ))}
             </div>
           )}
-          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">System</div>
-          <pre className="rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedSystem || '(empty)'}</code></pre>
-          <div className="h-2" />
-          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">User</div>
-          <pre className="rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedUser || '(empty)'}</code></pre>
+          <div className="preview-section">
+            <div className="preview-label">System</div>
+            <pre className="preview-text"><code>{composedSystem || '(empty)'}</code></pre>
+          </div>
+          <div className="preview-section">
+            <div className="preview-label">User</div>
+            <pre className="preview-text"><code>{composedUser || '(empty)'}</code></pre>
+          </div>
         </div>
       </div>
       </div>
@@ -287,7 +296,7 @@ function AutoGrowTextarea({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className="w-full resize-none rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 break-words overflow-hidden"
+      className="textarea"
       style={{ minHeight }}
       wrap="soft"
     />
@@ -298,15 +307,15 @@ function SystemOptimizationNotes() {
   const info = usePromptStore((s) => s.systemOptInfo)
   if (!info) return null
   return (
-    <div className="mt-2 rounded-md border border-amber-300/40 dark:border-amber-300/20 bg-amber-50/60 dark:bg-amber-400/10 p-2">
-      <div className="text-xs font-medium text-amber-900 dark:text-amber-200">System prompt optimized</div>
+    <div className="callout warning">
+      <div className="callout-title">System prompt optimized</div>
       {info.changes.length > 0 && (
-        <ul className="list-disc pl-4 text-xs mt-1 space-y-0.5">
+        <ul className="callout-list">
           {info.changes.slice(0, 5).map((c, i) => (<li key={i}>{c}</li>))}
         </ul>
       )}
       {info.notes.length > 0 && (
-        <div className="text-[11px] text-amber-800/80 dark:text-amber-200/80 mt-1">{info.notes.join(' ')}</div>
+        <div className="callout-notes">{info.notes.join(' ')}</div>
       )}
     </div>
   )
@@ -316,15 +325,15 @@ function UserOptimizationNotes() {
   const info = usePromptStore((s) => s.userOptInfo)
   if (!info) return null
   return (
-    <div className="mt-2 rounded-md border border-emerald-300/40 dark:border-emerald-300/20 bg-emerald-50/60 dark:bg-emerald-400/10 p-2">
-      <div className="text-xs font-medium text-emerald-900 dark:text-emerald-200">User prompt optimized</div>
+    <div className="callout success">
+      <div className="callout-title">User prompt optimized</div>
       {info.changes.length > 0 && (
-        <ul className="list-disc pl-4 text-xs mt-1 space-y-0.5">
+        <ul className="callout-list">
           {info.changes.slice(0, 5).map((c, i) => (<li key={i}>{c}</li>))}
         </ul>
       )}
       {info.notes.length > 0 && (
-        <div className="text-[11px] text-emerald-800/80 dark:text-emerald-200/80 mt-1">{info.notes.join(' ')}</div>
+        <div className="callout-notes">{info.notes.join(' ')}</div>
       )}
     </div>
   )

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -4,18 +4,12 @@ export function ToastContainer() {
   const toasts = useToastStore((s) => s.toasts)
   const remove = useToastStore((s) => s.remove)
   return (
-    <div className="fixed bottom-4 right-4 z-50 space-y-2">
+    <div className="toast-container">
       {toasts.map((t) => (
         <div
           key={t.id}
           role="status"
-          className={[
-            'min-w-[220px] max-w-[360px] rounded-md shadow border px-3 py-2 text-sm',
-            'backdrop-blur bg-white/80 dark:bg-gray-900/80',
-            t.type === 'success' ? 'border-emerald-300 text-emerald-900 dark:text-emerald-200' : '',
-            t.type === 'error' ? 'border-rose-300 text-rose-900 dark:text-rose-200' : '',
-            t.type === 'info' ? 'border-blue-300 text-blue-900 dark:text-blue-200' : '',
-          ].join(' ')}
+          className={`toast ${t.type}`}
           onClick={() => remove(t.id)}
         >
           {t.message}
@@ -24,4 +18,3 @@ export function ToastContainer() {
     </div>
   )
 }
-

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,168 +1,501 @@
-@import "tailwindcss";
-
-/* Configure Tailwind v4 to use class-based dark mode ONLY */
-@variant dark (&:is(.dark *));
-
-/* App base styles can go here if needed later */
-
-.use-app-font {
-  font-family: var(--app-font), ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Noto Sans, "Apple Color Emoji", "Segoe UI Emoji";
+:root {
+  --bg-page: #f3f4f6;
+  --bg-surface: #ffffff;
+  --bg-surface-strong: #f0f1f5;
+  --border-color: #d9dde6;
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --primary: #5b6ef5;
+  --primary-tonal: #e7e9ff;
+  --primary-strong: #3d4fcc;
+  --shadow-soft: 0 8px 20px rgba(15, 23, 42, 0.08);
+  --radius: 14px;
 }
 
-/* Enhanced markdown/prose styling for better readability */
+.dark {
+  --bg-page: #0f1116;
+  --bg-surface: #161a23;
+  --bg-surface-strong: #1f2430;
+  --border-color: #2a3040;
+  --text-primary: #e5e7eb;
+  --text-secondary: #cbd5e1;
+  --primary: #8ba2ff;
+  --primary-tonal: #1f2b4d;
+  --primary-strong: #6a86ff;
+  --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-page);
+  color: var(--text-primary);
+  font-family: 'Inter', 'Roboto', system-ui, -apple-system, sans-serif;
+  line-height: 1.6;
+  text-rendering: optimizeLegibility;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+
+.workspace {
+  padding: 16px;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  height: 64px;
+  padding: 0 18px;
+  background: var(--bg-surface);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: var(--shadow-soft);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-text .title {
+  display: block;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.brand-text .subtitle {
+  display: block;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.action-bar {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.button {
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.button:hover {
+  border-color: var(--primary);
+  box-shadow: var(--shadow-soft);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.button.tonal {
+  background: var(--primary-tonal);
+  border-color: transparent;
+  color: var(--primary-strong);
+}
+
+.button.text {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-secondary);
+}
+
+.icon-button {
+  height: 36px;
+  width: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.icon-button.subtle {
+  border-color: transparent;
+  background: var(--bg-surface-strong);
+}
+
+.icon-button:hover {
+  border-color: var(--primary);
+  box-shadow: var(--shadow-soft);
+}
+
+.icon {
+  height: 16px;
+  width: 16px;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+}
+
+.canvas {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  min-height: calc(100vh - 96px);
+}
+
+.panel {
+  min-width: 0;
+}
+
+.surface-card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  padding: 12px;
+  min-height: calc(100vh - 140px);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px 12px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  text-transform: capitalize;
+}
+
+.section-body {
+  padding: 12px 4px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.section-subheader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.label-group {
+  display: grid;
+  gap: 4px;
+}
+
+.label {
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.label.with-icon svg {
+  height: 16px;
+  width: 16px;
+}
+
+.helper {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.meta-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.section-divider {
+  padding: 2px 0 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.section-divider .section-subheader {
+  padding: 6px 0;
+}
+
+.textarea,
+.text-input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface-strong);
+  color: var(--text-primary);
+  font-size: 14px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.textarea:focus,
+.text-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 30%, transparent);
+}
+
+.textarea {
+  resize: none;
+  line-height: 1.5;
+}
+
+.variable-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.variable-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.empty-state {
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 6px 0;
+}
+
+.preview-block {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 8px;
+}
+
+.preview-section {
+  display: grid;
+  gap: 6px;
+}
+
+.preview-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.preview-text {
+  margin: 0;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface-strong);
+  white-space: pre-wrap;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--bg-surface-strong);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  font-size: 12px;
+}
+
+.callout {
+  border-radius: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface-strong);
+}
+
+.callout.warning {
+  border-color: #fbbf24;
+  background: color-mix(in srgb, #fbbf24 12%, transparent);
+}
+
+.callout.success {
+  border-color: #34d399;
+  background: color-mix(in srgb, #34d399 12%, transparent);
+}
+
+.callout-title {
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.callout-list {
+  margin: 8px 0;
+  padding-left: 18px;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.callout-notes {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.drawer {
+  position: relative;
+  overflow: hidden;
+}
+
+.drawer-surface {
+  height: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-color);
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+.drawer-content {
+  padding: 10px 12px;
+  overflow: auto;
+  height: 100%;
+}
+
+.drawer-content.padded {
+  padding: 16px;
+}
+
+.resize-handle {
+  position: absolute;
+  top: 0;
+  width: 10px;
+  height: 100%;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.right-handle { right: 0; }
+.left-handle { left: 0; }
+
+.resize-indicator {
+  width: 3px;
+  height: 48px;
+  border-radius: 999px;
+  background: var(--border-color);
+}
+
+.prompt-editor {
+  min-height: calc(100vh - 140px);
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 50;
+}
+
+.toast {
+  min-width: 240px;
+  max-width: 360px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-surface);
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.toast.success { border-color: #34d399; color: #0f5132; }
+.toast.error { border-color: #f87171; color: #7f1d1d; }
+.toast.info { border-color: var(--primary); color: var(--text-primary); }
+
+/* Utility bridge for legacy class names */
+[class*="flex"] { display: flex; }
+[class*="flex-1"] { flex: 1 1 0%; }
+[class*="flex-shrink-0"] { flex-shrink: 0; }
+[class*="items-center"] { align-items: center; }
+[class*="items-start"] { align-items: flex-start; }
+[class*="justify-between"] { justify-content: space-between; }
+[class*="justify-end"] { justify-content: flex-end; }
+[class*="justify-center"] { justify-content: center; }
+[class*="gap-1"] { gap: 4px; }
+[class*="gap-2"] { gap: 8px; }
+[class*="gap-3"] { gap: 12px; }
+[class*="gap-4"] { gap: 16px; }
+[class*="px-4"] { padding-left: 16px; padding-right: 16px; }
+[class*="py-3"] { padding-top: 12px; padding-bottom: 12px; }
+[class*="py-2"] { padding-top: 8px; padding-bottom: 8px; }
+[class*="px-3"] { padding-left: 12px; padding-right: 12px; }
+[class*="p-2"] { padding: 8px; }
+[class*="p-3"] { padding: 12px; }
+[class*="rounded-md"] { border-radius: 12px; }
+[class*="rounded"] { border-radius: 8px; }
+[class*="border"] { border: 1px solid var(--border-color); }
+[class*="text-xs"] { font-size: 12px; }
+[class*="text-sm"] { font-size: 14px; }
+[class*="text-[13px]"] { font-size: 13px; }
+[class*="font-medium"] { font-weight: 600; }
+[class*="font-semibold"] { font-weight: 700; }
+[class*="h-10"] { height: 40px; }
+[class*="h-14"] { height: 56px; }
+[class*="min-h-[calc(100vh-3.5rem)]"] { min-height: calc(100vh - 56px); }
+[class*="min-w-0"] { min-width: 0; }
+[class*="w-full"] { width: 100%; }
+
+/* Markdown styling */
 .prose {
-  color: #1f2937;
-
-  /* Paragraph spacing */
-  p {
-    margin-top: 1em;
-    margin-bottom: 1em;
-  }
-
-  /* First paragraph no top margin */
-  > :first-child {
-    margin-top: 0;
-  }
-
-  /* Last element no bottom margin */
-  > :last-child {
-    margin-bottom: 0;
-  }
-
-  /* Heading spacing */
-  h1, h2, h3, h4, h5, h6 {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    font-weight: 600;
-    line-height: 1.3;
-  }
-
-  h1 { font-size: 1.5em; }
-  h2 { font-size: 1.3em; }
-  h3 { font-size: 1.15em; }
-
-  /* List spacing */
-  ul, ol {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1.5em;
-  }
-
-  li {
-    margin-top: 0.25em;
-    margin-bottom: 0.25em;
-  }
-
-  /* Code blocks */
-  pre {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding: 1em;
-    border-radius: 0.5em;
-    overflow-wrap: break-word;
-    white-space: pre-wrap;
-    word-break: break-word;
-    background-color: #1f2937 !important;
-    color: #e5e7eb;
-  }
-
-  /* Inline code */
-  code {
-    padding: 0.2em 0.4em;
-    border-radius: 0.25em;
-    font-size: 0.9em;
-    background-color: #1f2937 !important;
-    color: #e5e7eb;
-    word-break: break-word;
-  }
-
-  /* Code inside pre shouldn't have double background */
-  pre code {
-    padding: 0;
-    background-color: transparent !important;
-    color: inherit;
-  }
-
-  /* Blockquotes */
-  blockquote {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1em;
-    border-left: 3px solid #d1d5db;
-    font-style: italic;
-    color: #6b7280;
-  }
-
-  /* Tables */
-  table {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  th, td {
-    padding: 0.5em;
-    border: 1px solid #e5e7eb;
-  }
-
-  th {
-    background-color: #f9fafb;
-    font-weight: 600;
-  }
-
-  /* Links */
-  a {
-    color: rgb(37 99 235);
-    text-decoration: underline;
-  }
-
-  /* Horizontal rules */
-  hr {
-    margin-top: 1.5em;
-    margin-bottom: 1.5em;
-    border-color: #e5e7eb;
-  }
+  color: var(--text-primary);
 }
 
-/* Dark mode overrides for prose */
-.dark .prose {
-  color: #e5e7eb;
+.prose a { color: var(--primary); }
 
-  pre {
-    background-color: #0a0c10 !important;
-    color: #e5e7eb;
-  }
-
-  code {
-    background-color: #0a0c10 !important;
-    color: #e5e7eb;
-  }
-
-  pre code {
-    background-color: transparent !important;
-    color: inherit;
-  }
-
-  blockquote {
-    border-left-color: rgba(255, 255, 255, 0.2);
-    color: #9ca3af;
-  }
-
-  th, td {
-    border-color: rgba(255, 255, 255, 0.1);
-  }
-
-  th {
-    background-color: rgba(255, 255, 255, 0.05);
-  }
-
-  a {
-    color: rgb(96 165 250);
-  }
-
-  hr {
-    border-color: rgba(255, 255, 255, 0.1);
-  }
-}
-
+.dark .prose { color: var(--text-primary); }


### PR DESCRIPTION
## Summary
- replace Tailwind-heavy layout with material-inspired surfaces, drawers, and controls
- add custom design tokens and utility bridge styling for light and dark modes without glassmorphism
- refresh prompt editor, header, and toasts with new buttons, callouts, and preview chips for progressive disclosure

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692004bff014832b9770bfd07b32673d)