### PR TITLE
Adopt material-inspired UI styling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,17 +15,17 @@ import { PanelLeft, Settings2 } from 'lucide-react'
 export default function App() {
   return (
     <>
-    <div className="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100 antialiased font-sans use-app-font">
-      <Header />
-      <main>
-        <DesktopPushLayout />
-      </main>
-    </div>
-    <SettingsSheet />
-    <LeftDrawer />
-    <UserSettingsScreen />
-    <PromptGuidanceModal />
-    <ToastContainer />
+      <div className="app-shell">
+        <Header />
+        <main className="app-main">
+          <DesktopPushLayout />
+        </main>
+      </div>
+      <SettingsSheet />
+      <LeftDrawer />
+      <UserSettingsScreen />
+      <PromptGuidanceModal />
+      <ToastContainer />
     </>
   )
 }
@@ -41,72 +41,57 @@ function DesktopPushLayout() {
   const setRightWidth = useUIStore((s) => s.setRightWidth)
   
   return (
-    <div className="hidden lg:flex gap-0 relative items-stretch">
-      {/* Left push drawer */}
-      <aside 
-        className={`relative flex-shrink-0 ${leftOpen ? 'self-stretch' : 'w-0 overflow-hidden'}`}
+    <div className="desktop-layout">
+      <aside
+        className={`side-panel left ${leftOpen ? 'open' : ''}`}
         style={{ width: leftOpen ? `${leftWidth}px` : undefined, transition: leftOpen ? 'none' : 'width 300ms ease-in-out' }}
+        aria-hidden={!leftOpen}
       >
         {leftOpen && (
           <>
-            <div className="h-full bg-gray-50/50 dark:bg-gray-900/50 backdrop-blur-sm border-r border-gray-200 dark:border-white/10">
-              {/* Drawer header with close button */}
-              <div className="h-10 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10 sticky top-0 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
-                <button
-                  onClick={toggleLeft}
-                  className="p-1.5 -ml-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
-                  aria-label="Close history"
-                >
-                  <PanelLeft className="h-4 w-4" />
+            <div className="panel-shell">
+              <div className="panel-header compact">
+                <button onClick={toggleLeft} className="icon-button" aria-label="Close history">
+                  <PanelLeft className="icon" />
                 </button>
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Library</span>
+                <span className="label">Library</span>
               </div>
-              {/* Drawer content */}
-              <div className="px-4 py-3">
+              <div className="panel-body inset">
                 <HistoryPanel bare />
               </div>
             </div>
-            {/* Resize handle */}
             <ResizeHandle side="right" onResize={setLeftWidth} currentWidth={leftWidth} />
           </>
         )}
       </aside>
 
-      {/* Main work area with full-height divider between columns */}
-      <section className="flex-1 min-w-0 min-h-[calc(100vh-3.5rem)] flex transition-all duration-300">
-        <div className="flex-1 min-w-0 border-r border-gray-200 dark:border-white/10">
+      <section className="workspace">
+        <div className="workspace-column">
           <PromptEditor />
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="workspace-column">
           <ResponsePanel />
         </div>
       </section>
 
-      {/* Right push drawer */}
-      <aside 
-        className={`relative flex-shrink-0 ${settingsOpen ? 'self-stretch' : 'w-0 overflow-hidden'}`}
+      <aside
+        className={`side-panel right ${settingsOpen ? 'open' : ''}`}
         style={{ width: settingsOpen ? `${rightWidth}px` : undefined, transition: settingsOpen ? 'none' : 'width 300ms ease-in-out' }}
+        aria-hidden={!settingsOpen}
       >
         {settingsOpen && (
           <>
-            <div className="h-full bg-gray-50/50 dark:bg-gray-900/50 backdrop-blur-sm border-l border-gray-200 dark:border-white/10">
-              {/* Drawer header with close button */}
-              <div className="h-10 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10 sticky top-0 bg-gray-50/80 dark:bg-gray-900/80 backdrop-blur-sm z-10">
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-200">Model Settings</span>
-                <button
-                  onClick={toggleRight}
-                  className="p-1.5 -mr-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
-                  aria-label="Close settings"
-                >
-                  <Settings2 className="h-4 w-4" />
+            <div className="panel-shell">
+              <div className="panel-header compact">
+                <span className="label">Model Settings</span>
+                <button onClick={toggleRight} className="icon-button" aria-label="Close settings">
+                  <Settings2 className="icon" />
                 </button>
               </div>
-              {/* Drawer content */}
-              <div className="px-6 py-4">
+              <div className="panel-body inset">
                 <SettingsContent />
               </div>
             </div>
-            {/* Resize handle */}
             <ResizeHandle side="left" onResize={setRightWidth} currentWidth={rightWidth} />
           </>
         )}
@@ -141,10 +126,10 @@ function ResizeHandle({ side, onResize, currentWidth }: { side: 'left' | 'right'
 
   return (
     <div
-      className={`absolute top-0 ${side === 'right' ? 'right-0' : 'left-0'} h-full w-1 cursor-col-resize hover:bg-blue-500/50 active:bg-blue-500 group z-20`}
+      className={`resize-handle ${side}`}
       onMouseDown={handleMouseDown}
     >
-      <div className={`sticky top-1/2 -translate-y-1/2 ${side === 'right' ? 'right-0.5' : 'left-0.5'} w-1 h-12 bg-gray-400 dark:bg-gray-500 rounded-full opacity-0 group-hover:opacity-100 transition-opacity`} />
+      <div className="resize-grip" />
     </div>
   )
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -10,34 +10,28 @@ export function Header() {
   const toggleTheme = useThemeStore((s) => s.toggleTheme)
 
   return (
-    <header className="sticky top-0 z-20 border-b border-gray-200/70 dark:border-white/10 backdrop-blur bg-white/70 dark:bg-gray-950/60">
-      <div className="h-14 flex items-center justify-between gap-3 px-4">
-        <div className="flex items-center gap-3">
+    <header className="app-header">
+      <div className="topbar">
+        <div className="topbar-brand">
           <Logo size="md" />
-          <span className="font-semibold">Prompt Engineering Studio</span>
+          <span className="brand-title">Prompt Engineering Studio</span>
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={openPromptGuidance}
-            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-white/15 px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <BookOpen className="h-4 w-4" />
+        <div className="topbar-actions">
+          <button onClick={openPromptGuidance} className="chip-button">
+            <BookOpen className="icon" />
             Prompt Guidance
           </button>
-          <button
-            onClick={openUserSettings}
-            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-white/15 px-3 py-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <SlidersHorizontal className="h-4 w-4" />
+          <button onClick={openUserSettings} className="chip-button">
+            <SlidersHorizontal className="icon" />
             Settings
           </button>
           <button
             onClick={toggleTheme}
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-white/15 p-2 text-sm hover:bg-gray-100 dark:hover:bg-white/10"
+            className="icon-button"
             aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
             title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
           >
-            {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            {theme === 'dark' ? <Sun className="icon" /> : <Moon className="icon" />}
           </button>
         </div>
       </div>

--- a/frontend/src/components/LeftDrawer.tsx
+++ b/frontend/src/components/LeftDrawer.tsx
@@ -8,8 +8,8 @@ export function LeftDrawer() {
   if (!open) return null
   return (
     <div className="fixed inset-0 z-30 lg:hidden" aria-modal="true" role="dialog">
-      <button className="absolute inset-0 bg-black/30 backdrop-blur-sm" aria-label="Close panels" onClick={close} />
-      <div className="absolute left-0 top-0 h-full w-[min(92vw,420px)] bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur-md border-r border-gray-200 dark:border-white/10 shadow-xl flex flex-col">
+      <button className="drawer-scrim" aria-label="Close panels" onClick={close} />
+      <div className="sheet-panel">
         <div className="h-12 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10">
           <div className="font-medium">History</div>
           <button onClick={close} className="rounded-md p-2 hover:bg-gray-100 dark:hover:bg-white/10" aria-label="Close">

--- a/frontend/src/components/ModelDetails.tsx
+++ b/frontend/src/components/ModelDetails.tsx
@@ -45,10 +45,10 @@ export function ModelDetails() {
                 <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">Supported parameters</div>
                 <div className="flex flex-wrap gap-1.5">
                   {supported.slice(0, 24).map((p: string) => (
-                    <span key={p} className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15">{p}</span>
+                    <span key={p} className="text-xs px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15">{p}</span>
                   ))}
                   {supported.length > 24 && (
-                    <span className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15">+{supported.length - 24} more</span>
+                    <span className="text-xs px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15">+{supported.length - 24} more</span>
                   )}
                 </div>
               </div>

--- a/frontend/src/components/ParametersPanel.tsx
+++ b/frontend/src/components/ParametersPanel.tsx
@@ -56,7 +56,7 @@ export function ParametersPanel() {
         <div className="mb-3 rounded-md border border-blue-300/40 dark:border-blue-300/20 bg-blue-50/60 dark:bg-blue-400/10 p-2">
           <div className="flex items-start justify-between gap-2">
             <div className="text-xs text-blue-950 dark:text-blue-200">{presetExplainer}</div>
-            <button onClick={dismissPresetExplainer} className="text-[11px] rounded border border-blue-300/60 px-1.5 py-0.5 hover:bg-blue-100/60 dark:hover:bg-blue-300/20">Dismiss</button>
+            <button onClick={dismissPresetExplainer} className="text-xs rounded border border-blue-300/60 px-1.5 py-0.5 hover:bg-blue-100/60 dark:hover:bg-blue-300/20">Dismiss</button>
           </div>
         </div>
       )}

--- a/frontend/src/components/PromptEditor.tsx
+++ b/frontend/src/components/PromptEditor.tsx
@@ -96,37 +96,33 @@ export function PromptEditor() {
   const toggleLeft = useUIStore((s) => s.toggleLeft)
 
   return (
-    <section className="min-h-[calc(100vh-3.5rem)]">
-      <div className="h-10 border-b border-gray-200 dark:border-white/10 flex items-center justify-between px-4 sticky top-0 bg-white dark:bg-gray-950 z-10">
-        <div className="flex items-center gap-2">
+    <section className="section-block prompt-panel">
+      <div className="surface-row sticky top-0" style={{ background: 'var(--bg-raised)', zIndex: 2 }}>
+        <div className="button-row">
           {!leftOpen && (
-            <button
-              onClick={toggleLeft}
-              className="p-1 -ml-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/10 text-gray-600 dark:text-gray-300 transition-colors"
-              aria-label="Open library"
-            >
-              <PanelLeft className="h-4 w-4" />
+            <button onClick={toggleLeft} className="icon-button" aria-label="Open library">
+              <PanelLeft className="icon" />
             </button>
           )}
-          <div className="font-medium">Prompt Editor</div>
+          <div className="section-title">Prompt Editor</div>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="text-xs text-gray-500 dark:text-gray-400">Estimated tokens: {estimatedTokens}</div>
-          <button onClick={reset} className="text-xs rounded-md border border-gray-300 dark:border-white/15 px-2.5 py-1 hover:bg-gray-100 dark:hover:bg-white/10">Clear</button>
+        <div className="button-row">
+          <div className="meta-text">Estimated tokens: {estimatedTokens}</div>
+          <button onClick={reset} className="tonal-button text-xs">Clear</button>
         </div>
       </div>
-      <div className="px-4 py-3 overflow-hidden">
-      <div className="flex items-center justify-between mb-1">
-        <label className="block text-sm text-gray-600 dark:text-gray-300">System prompt (optional)</label>
-        <div className="flex items-center gap-2">
+      <div className="panel-body inset">
+      <div className="surface-row">
+        <label className="section-title text-sm">System prompt (optional)</label>
+        <div className="button-row">
           {originalSystemPrompt && (
             <button
               type="button"
               onClick={revertSystemPrompt}
-              className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
+              className="tonal-button text-xs"
               title="Revert to original"
             >
-              <Undo2 className="h-3.5 w-3.5" />
+              <Undo2 className="icon" />
               Revert
             </button>
           )}
@@ -134,9 +130,9 @@ export function PromptEditor() {
             type="button"
             onClick={() => optimizeField('system')}
             disabled={!systemPrompt.trim() || optimizing.system}
-            className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 disabled:opacity-50 hover:bg-gray-100 dark:hover:bg-white/10"
+            className="primary-button text-xs"
           >
-            <Wand2 className="h-3.5 w-3.5" />
+            <Wand2 className="icon" />
             {optimizing.system ? 'Optimizing…' : 'Optimize'}
           </button>
         </div>
@@ -184,84 +180,89 @@ export function PromptEditor() {
 
       {/* Variables editor */}
       <div className="mt-4">
-        {/* Full-width divider line that reaches the column edge */}
-        <div className="-mx-4 px-4">
-          <div className="h-10 flex items-center justify-between border-b border-gray-200 dark:border-white/10 mb-2">
-          <div className="flex items-center gap-2">
-            <Braces className="h-4 w-4" />
-            <div className="font-medium">Variables</div>
-            <div className="text-xs text-gray-500">Use {'{{variable}}'} in prompts</div>
-          </div>
-          <button onClick={addVariable} className="text-xs inline-flex items-center gap-1 rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10">
-            <Plus className="h-3.5 w-3.5" />
-            Add
-          </button>
-          </div>
-        </div>
-        {variables.length === 0 ? (
-          <div className="text-xs text-gray-500 px-1">No variables yet.</div>
-        ) : (
-          <div className="space-y-2">
-            {variables.map((v, i) => (
-              <div key={i} className="grid grid-cols-12 gap-2 items-center px-1">
-                <input
-                  value={v.name}
-                  onChange={(e) => updateVariableName(i, e.target.value)}
-                  placeholder="name"
-                  className="col-span-5 text-sm rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <input
-                  value={v.value}
-                  onChange={(e) => updateVariableValue(i, e.target.value)}
-                  placeholder="value"
-                  className="col-span-6 text-sm rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-2.5 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-                <button
-                  onClick={() => removeVariable(i)}
-                  aria-label="Remove variable"
-                  className="col-span-1 text-xs rounded-md border border-gray-300 dark:border-white/15 px-2 py-1 hover:bg-gray-100 dark:hover:bg-white/10"
-                >×</button>
+        <details className="details-tile" open={variables.length > 0}>
+          <summary data-chevron>{
+            <div className="surface-row" style={{ marginBottom: 0 }}>
+              <div className="button-row">
+                <Braces className="icon" />
+                <div className="section-title">Variables</div>
+                <div className="meta-text">Use {'{{variable}}'} in prompts</div>
               </div>
-            ))}
+              <button onClick={(e) => { e.preventDefault(); addVariable() }} className="tonal-button text-xs">
+                <Plus className="icon" />
+                Add
+              </button>
+            </div>
+          }</summary>
+          <div className="space-y-2 mt-2">
+            {variables.length === 0 ? (
+              <div className="meta-text">No variables yet.</div>
+            ) : (
+              variables.map((v, i) => (
+                <div key={i} className="variable-row">
+                  <input
+                    value={v.name}
+                    onChange={(e) => updateVariableName(i, e.target.value)}
+                    placeholder="name"
+                    className="input-field"
+                  />
+                  <input
+                    value={v.value}
+                    onChange={(e) => updateVariableValue(i, e.target.value)}
+                    placeholder="value"
+                    className="input-field"
+                  />
+                  <button
+                    onClick={() => removeVariable(i)}
+                    aria-label="Remove variable"
+                    className="icon-button"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))
+            )}
           </div>
-        )}
+        </details>
       </div>
 
       {/* Prompt Preview */}
       <div className="mt-4">
-        {/* Full-width divider line that reaches the column edge */}
-        <div className="-mx-4 px-4">
-          <div className="h-10 flex items-center justify-between border-b border-gray-200 dark:border-white/10 mb-2">
-          <div className="font-medium">Prompt Preview</div>
-          <button
-            onClick={async () => {
-              const text = `System:\n${composedSystem || '(empty)'}\n\nUser:\n${composedUser || '(empty)'}\n`
-              try { await navigator.clipboard.writeText(text) } catch {}
-            }}
-            aria-label="Copy composed prompt"
-            title="Copy composed prompt"
-            className="rounded-md p-2 border border-gray-300 dark:border-white/15 hover:bg-gray-100 dark:hover:bg-white/10"
-          >
-            <Copy className="h-4 w-4" />
-          </button>
-          </div>
-        </div>
-        <div className="px-0 text-[13px] leading-snug whitespace-pre-wrap text-gray-800 dark:text-gray-100">
-          {usedVars.length > 0 && (
-            <div className="mb-2 flex flex-wrap gap-1.5">
-              {usedVars.map(v => (
-                <span key={v.name} className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 dark:border-white/15 bg-white/60 dark:bg-white/5">
-                  {v.name}: {v.value || '(empty)'}
-                </span>
-              ))}
+        <details className="details-tile" open>
+          <summary data-chevron>
+            <div className="surface-row" style={{ marginBottom: 0 }}>
+              <div className="section-title">Prompt Preview</div>
+              <button
+                onClick={async (e) => {
+                  e.preventDefault()
+                  const text = `System:\n${composedSystem || '(empty)'}\n\nUser:\n${composedUser || '(empty)'}\n`
+                  try { await navigator.clipboard.writeText(text) } catch {}
+                }}
+                aria-label="Copy composed prompt"
+                title="Copy composed prompt"
+                className="icon-button"
+              >
+                <Copy className="icon" />
+              </button>
             </div>
-          )}
-          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">System</div>
-          <pre className="rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedSystem || '(empty)'}</code></pre>
-          <div className="h-2" />
-          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">User</div>
-          <pre className="rounded-md border border-gray-200 dark:border-white/10 bg-white/50 dark:bg-white/5 p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedUser || '(empty)'}</code></pre>
-        </div>
+          </summary>
+          <div className="text-sm leading-snug whitespace-pre-wrap text-gray-800 dark:text-gray-100 mt-2">
+            {usedVars.length > 0 && (
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {usedVars.map(v => (
+                  <span key={v.name} className="chip-quiet">
+                    {v.name}: {v.value || '(empty)'}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">System</div>
+            <pre className="rounded-md border p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedSystem || '(empty)'}</code></pre>
+            <div style={{ height: 8 }} />
+            <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">User</div>
+            <pre className="rounded-md border p-2 whitespace-pre-wrap break-words overflow-hidden"><code>{composedUser || '(empty)'}</code></pre>
+          </div>
+        </details>
       </div>
       </div>
     </section>
@@ -287,7 +288,7 @@ function AutoGrowTextarea({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className="w-full resize-none rounded-md bg-transparent border border-gray-300 dark:border-white/15 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 break-words overflow-hidden"
+      className="input-field"
       style={{ minHeight }}
       wrap="soft"
     />
@@ -298,15 +299,15 @@ function SystemOptimizationNotes() {
   const info = usePromptStore((s) => s.systemOptInfo)
   if (!info) return null
   return (
-    <div className="mt-2 rounded-md border border-amber-300/40 dark:border-amber-300/20 bg-amber-50/60 dark:bg-amber-400/10 p-2">
-      <div className="text-xs font-medium text-amber-900 dark:text-amber-200">System prompt optimized</div>
+    <div className="alert warning mt-2">
+      <div className="text-xs font-medium">System prompt optimized</div>
       {info.changes.length > 0 && (
         <ul className="list-disc pl-4 text-xs mt-1 space-y-0.5">
           {info.changes.slice(0, 5).map((c, i) => (<li key={i}>{c}</li>))}
         </ul>
       )}
       {info.notes.length > 0 && (
-        <div className="text-[11px] text-amber-800/80 dark:text-amber-200/80 mt-1">{info.notes.join(' ')}</div>
+        <div className="text-xs mt-1">{info.notes.join(' ')}</div>
       )}
     </div>
   )
@@ -316,15 +317,15 @@ function UserOptimizationNotes() {
   const info = usePromptStore((s) => s.userOptInfo)
   if (!info) return null
   return (
-    <div className="mt-2 rounded-md border border-emerald-300/40 dark:border-emerald-300/20 bg-emerald-50/60 dark:bg-emerald-400/10 p-2">
-      <div className="text-xs font-medium text-emerald-900 dark:text-emerald-200">User prompt optimized</div>
+    <div className="alert success mt-2">
+      <div className="text-xs font-medium">User prompt optimized</div>
       {info.changes.length > 0 && (
         <ul className="list-disc pl-4 text-xs mt-1 space-y-0.5">
           {info.changes.slice(0, 5).map((c, i) => (<li key={i}>{c}</li>))}
         </ul>
       )}
       {info.notes.length > 0 && (
-        <div className="text-[11px] text-emerald-800/80 dark:text-emerald-200/80 mt-1">{info.notes.join(' ')}</div>
+        <div className="text-xs mt-1">{info.notes.join(' ')}</div>
       )}
     </div>
   )

--- a/frontend/src/components/PromptGuidanceModal.tsx
+++ b/frontend/src/components/PromptGuidanceModal.tsx
@@ -178,8 +178,8 @@ export function PromptGuidanceModal() {
     : null
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/40 backdrop-blur-md flex items-center justify-center p-4">
-      <div className="w-[min(1200px,95vw)] h-[min(900px,90vh)] bg-gray-50 dark:bg-[#1a1d29] rounded-xl border border-gray-200 dark:border-white/10 shadow-xl overflow-hidden flex flex-col">
+    <div className="modal-layer" style={{ padding: '16px' }}>
+      <div className="guidance-surface">
         {/* Header with Tabs */}
         <div className="bg-white dark:bg-gray-950 border-b border-gray-200 dark:border-white/10">
           {/* Title and Close */}

--- a/frontend/src/components/ResponseFootnotes.tsx
+++ b/frontend/src/components/ResponseFootnotes.tsx
@@ -29,7 +29,7 @@ export function ResponseFootnotes({ run }: Props) {
         <div className="mt-2">
           {groups.map(([h, arr], gi) => (
             <div key={gi} className="mb-2">
-              <div className="text-[11px] font-semibold text-gray-700 dark:text-gray-300 mb-1">{h}</div>
+              <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-1">{h}</div>
               <ol className="space-y-1 text-xs text-gray-600 dark:text-gray-400">
                 {arr.map((l, i) => (
                   <li key={i} className="flex gap-2">

--- a/frontend/src/components/SettingsSheet.tsx
+++ b/frontend/src/components/SettingsSheet.tsx
@@ -21,11 +21,11 @@ export function SettingsSheet() {
   return (
     <div className="fixed inset-0 z-30 lg:hidden" aria-modal="true" role="dialog">
       <button
-        className="absolute inset-0 bg-black/30 backdrop-blur-sm"
+        className="drawer-scrim"
         aria-label="Close settings"
         onClick={close}
       />
-      <div className="absolute right-0 top-0 h-full w-[min(92vw,480px)] bg-white dark:bg-gray-950 border-l border-gray-200 dark:border-white/10 shadow-xl flex flex-col">
+      <div className="sheet-panel right">
         <div className="h-12 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10">
           <div className="font-medium">Model & Settings</div>
           <button onClick={close} className="rounded-md p-2 hover:bg-gray-100 dark:hover:bg-white/10" aria-label="Close">

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -11,7 +11,7 @@ export function ToastContainer() {
           role="status"
           className={[
             'min-w-[220px] max-w-[360px] rounded-md shadow border px-3 py-2 text-sm',
-            'backdrop-blur bg-white/80 dark:bg-gray-900/80',
+            'bg-white dark:bg-gray-900',
             t.type === 'success' ? 'border-emerald-300 text-emerald-900 dark:text-emerald-200' : '',
             t.type === 'error' ? 'border-rose-300 text-rose-900 dark:text-rose-200' : '',
             t.type === 'info' ? 'border-blue-300 text-blue-900 dark:text-blue-200' : '',

--- a/frontend/src/components/ToolChips.tsx
+++ b/frontend/src/components/ToolChips.tsx
@@ -47,7 +47,7 @@ export function ToolChips({ run, onOpen }: Props) {
           <button
             key={name}
             onClick={() => onOpen?.(last?.id)}
-            className={`text-[11px] inline-flex items-center gap-1 px-2 py-1 rounded-md border ${statusColor(last?.status)} hover:opacity-90 transition-opacity`}
+            className={`text-xs inline-flex items-center gap-1 px-2 py-1 rounded-md border ${statusColor(last?.status)} hover:opacity-90 transition-opacity`}
             title={`${name} · ${steps.length} call${steps.length>1?'s':''}`}
             aria-label={`Open ${name} details`}
           >
@@ -59,7 +59,7 @@ export function ToolChips({ run, onOpen }: Props) {
       })}
       <button
         onClick={() => onOpen?.()}
-        className="text-[11px] inline-flex items-center gap-1 px-2 py-1 rounded-md border bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 border-gray-300/50 hover:opacity-90"
+        className="text-xs inline-flex items-center gap-1 px-2 py-1 rounded-md border bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200 border-gray-300/50 hover:opacity-90"
         title="Open Run details"
         aria-label="Open Run details"
       >

--- a/frontend/src/components/UserSettingsScreen.tsx
+++ b/frontend/src/components/UserSettingsScreen.tsx
@@ -11,8 +11,8 @@ export function UserSettingsScreen() {
   const setFont = useSettingsStore((s) => s.setFont)
   if (!open) return null
   return (
-    <div className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm flex">
-      <div className="mx-auto my-8 w-[min(920px,94vw)] bg-white dark:bg-gray-950 rounded-xl border border-gray-200 dark:border-white/10 shadow-xl flex flex-col">
+    <div className="modal-layer">
+      <div className="modal-surface">
         <div className="h-12 flex items-center justify-between px-4 border-b border-gray-200 dark:border-white/10">
           <div className="font-semibold text-gray-900 dark:text-white">Prompt Studio Settings</div>
           <button onClick={close} className="rounded-md p-2 border border-gray-300 dark:border-white/15 hover:bg-gray-100 dark:hover:bg-white/10 text-gray-900 dark:text-white" aria-label="Close">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,168 +1,598 @@
-@import "tailwindcss";
-
-/* Configure Tailwind v4 to use class-based dark mode ONLY */
-@variant dark (&:is(.dark *));
-
-/* App base styles can go here if needed later */
-
-.use-app-font {
-  font-family: var(--app-font), ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Noto Sans, "Apple Color Emoji", "Segoe UI Emoji";
+:root {
+  --bg: #f5f6fa;
+  --bg-raised: #ffffff;
+  --bg-muted: #eef0f6;
+  --text: #1c1e26;
+  --text-muted: #4a4e69;
+  --border: #d8dbe8;
+  --border-strong: #c2c6d6;
+  --primary: #3f51b5;
+  --primary-strong: #2f3d8f;
+  --primary-soft: #e3e7fb;
+  --accent: #00b8a3;
+  --shadow-soft: 0 6px 24px rgba(18, 22, 33, 0.08);
+  --shadow-strong: 0 12px 30px rgba(18, 22, 33, 0.12);
+  --radius-sm: 10px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --surface-padding: 16px;
 }
 
-/* Enhanced markdown/prose styling for better readability */
+.dark {
+  --bg: #0f121a;
+  --bg-raised: #181c24;
+  --bg-muted: #11141c;
+  --text: #e7e9f1;
+  --text-muted: #9ea4b8;
+  --border: #2a2f3c;
+  --border-strong: #363d4f;
+  --primary: #9fa8ff;
+  --primary-strong: #7f89ff;
+  --primary-soft: rgba(159, 168, 255, 0.12);
+  --accent: #4ad8c8;
+  --shadow-soft: 0 6px 24px rgba(0, 0, 0, 0.45);
+  --shadow-strong: 0 12px 30px rgba(0, 0, 0, 0.55);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", "Roboto", "SF Pro Display", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 8px 12px 16px;
+  gap: 12px;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: var(--bg-raised);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow-soft);
+}
+
+.topbar {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+  gap: 12px;
+}
+
+.topbar-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.brand-title {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.topbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.desktop-layout {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  min-height: calc(100vh - 64px);
+}
+
+.workspace {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  gap: 12px;
+  padding: 6px;
+}
+
+.workspace-column {
+  min-width: 0;
+}
+
+.side-panel {
+  position: relative;
+  flex-shrink: 0;
+  transition: width 0.25s ease;
+  background: var(--bg);
+  border-inline: 1px solid var(--border);
+}
+
+.side-panel.left {
+  border-left: none;
+}
+
+.side-panel.right {
+  border-right: none;
+}
+
+.side-panel:not(.open) {
+  width: 0;
+  overflow: hidden;
+}
+
+.panel-shell {
+  height: 100%;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 14px var(--surface-padding);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-muted);
+}
+
+.panel-header.compact {
+  padding: 12px var(--surface-padding);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
+.panel-body {
+  padding: 0 var(--surface-padding) var(--surface-padding);
+  overflow-y: auto;
+  flex: 1;
+}
+
+.panel-body.inset {
+  padding-top: var(--surface-padding);
+}
+
+.section-block {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: var(--surface-padding);
+  margin-bottom: 12px;
+}
+
+.section-title {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.surface-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.meta-text {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.button-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  background: var(--bg-muted);
+  color: var(--text);
+  border-radius: var(--radius-sm);
+  padding: 9px 12px;
+  font-weight: 600;
+  font-size: 13px;
+  border: 1px solid var(--border);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+}
+
+button:hover {
+  background: var(--primary-soft);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-soft);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.chip-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-raised);
+  border-color: var(--border);
+  padding: 10px 12px;
+  border-radius: 999px;
+}
+
+.primary-button {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary-strong);
+}
+
+.primary-button:hover {
+  background: var(--primary-strong);
+  color: #fff;
+}
+
+.tonal-button {
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+  border-color: transparent;
+}
+
+.icon-button {
+  width: 38px;
+  height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+}
+
+.icon-button:hover {
+  background: var(--primary-soft);
+}
+
+.card {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--surface-padding);
+  box-shadow: var(--shadow-soft);
+}
+
+.input-field,
+textarea,
+select,
+input[type="text"] {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-raised);
+  color: var(--text);
+  padding: 10px 12px;
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea {
+  resize: none;
+  line-height: 1.5;
+}
+
+.input-field:focus,
+textarea:focus,
+select:focus,
+input[type="text"]:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(63, 81, 181, 0.15);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.section-divider {
+  margin: 14px -4px;
+  height: 1px;
+  background: var(--border);
+}
+
+.alert {
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-muted);
+  font-size: 13px;
+}
+
+.alert.success {
+  border-color: #1ea672;
+  background: rgba(30, 166, 114, 0.12);
+  color: #0c5b3d;
+}
+
+.alert.warning {
+  border-color: #ffb020;
+  background: rgba(255, 176, 32, 0.12);
+  color: #7a5200;
+}
+
+.dark .alert.success {
+  color: #76f0c3;
+  background: rgba(74, 216, 200, 0.08);
+  border-color: #4ad8c8;
+}
+
+.dark .alert.warning {
+  color: #ffdb8a;
+  background: rgba(255, 176, 32, 0.12);
+  border-color: #ffb020;
+}
+
+.resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 10px;
+  cursor: col-resize;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.resize-handle.left { left: 0; }
+.resize-handle.right { right: 0; }
+
+.resize-grip {
+  width: 4px;
+  height: 56px;
+  border-radius: 999px;
+  background: var(--border-strong);
+  opacity: 0.55;
+}
+
+.details-tile {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-raised);
+  box-shadow: var(--shadow-soft);
+  padding: 12px 14px;
+}
+
+.details-tile summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.details-tile summary::-webkit-details-marker { display: none; }
+
+.details-tile summary::after {
+  content: attr(data-chevron);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.details-tile[open] summary::after { content: '▾'; }
+
+.details-tile:not([open]) summary::after { content: '▸'; }
+
+.drawer-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 12, 16, 0.55);
+  border: none;
+}
+
+.sheet-panel {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: min(92vw, 420px);
+  background: var(--bg-raised);
+  border-right: 1px solid var(--border);
+  box-shadow: var(--shadow-strong);
+  display: flex;
+  flex-direction: column;
+}
+
+.sheet-panel.right {
+  left: auto;
+  right: 0;
+  width: min(92vw, 480px);
+  border-right: none;
+  border-left: 1px solid var(--border);
+}
+
+.modal-layer {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 9, 14, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-surface {
+  width: min(920px, 94vw);
+  max-height: 90vh;
+  background: var(--bg-raised);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-strong);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.guidance-surface {
+  width: min(1200px, 95vw);
+  height: min(900px, 90vh);
+  background: var(--bg-raised);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-strong);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.variable-row {
+  display: grid;
+  grid-template-columns: 5fr 6fr auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.chip-quiet {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px dashed var(--border-strong);
+  background: var(--bg-muted);
+}
+
 .prose {
-  color: #1f2937;
-
-  /* Paragraph spacing */
-  p {
-    margin-top: 1em;
-    margin-bottom: 1em;
-  }
-
-  /* First paragraph no top margin */
-  > :first-child {
-    margin-top: 0;
-  }
-
-  /* Last element no bottom margin */
-  > :last-child {
-    margin-bottom: 0;
-  }
-
-  /* Heading spacing */
-  h1, h2, h3, h4, h5, h6 {
-    margin-top: 1.5em;
-    margin-bottom: 0.5em;
-    font-weight: 600;
-    line-height: 1.3;
-  }
-
-  h1 { font-size: 1.5em; }
-  h2 { font-size: 1.3em; }
-  h3 { font-size: 1.15em; }
-
-  /* List spacing */
-  ul, ol {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1.5em;
-  }
-
-  li {
-    margin-top: 0.25em;
-    margin-bottom: 0.25em;
-  }
-
-  /* Code blocks */
-  pre {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding: 1em;
-    border-radius: 0.5em;
-    overflow-wrap: break-word;
-    white-space: pre-wrap;
-    word-break: break-word;
-    background-color: #1f2937 !important;
-    color: #e5e7eb;
-  }
-
-  /* Inline code */
-  code {
-    padding: 0.2em 0.4em;
-    border-radius: 0.25em;
-    font-size: 0.9em;
-    background-color: #1f2937 !important;
-    color: #e5e7eb;
-    word-break: break-word;
-  }
-
-  /* Code inside pre shouldn't have double background */
-  pre code {
-    padding: 0;
-    background-color: transparent !important;
-    color: inherit;
-  }
-
-  /* Blockquotes */
-  blockquote {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    padding-left: 1em;
-    border-left: 3px solid #d1d5db;
-    font-style: italic;
-    color: #6b7280;
-  }
-
-  /* Tables */
-  table {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  th, td {
-    padding: 0.5em;
-    border: 1px solid #e5e7eb;
-  }
-
-  th {
-    background-color: #f9fafb;
-    font-weight: 600;
-  }
-
-  /* Links */
-  a {
-    color: rgb(37 99 235);
-    text-decoration: underline;
-  }
-
-  /* Horizontal rules */
-  hr {
-    margin-top: 1.5em;
-    margin-bottom: 1.5em;
-    border-color: #e5e7eb;
-  }
+  color: var(--text);
 }
 
-/* Dark mode overrides for prose */
-.dark .prose {
+.prose pre {
+  background: #0a0c10;
   color: #e5e7eb;
-
-  pre {
-    background-color: #0a0c10 !important;
-    color: #e5e7eb;
-  }
-
-  code {
-    background-color: #0a0c10 !important;
-    color: #e5e7eb;
-  }
-
-  pre code {
-    background-color: transparent !important;
-    color: inherit;
-  }
-
-  blockquote {
-    border-left-color: rgba(255, 255, 255, 0.2);
-    color: #9ca3af;
-  }
-
-  th, td {
-    border-color: rgba(255, 255, 255, 0.1);
-  }
-
-  th {
-    background-color: rgba(255, 255, 255, 0.05);
-  }
-
-  a {
-    color: rgb(96 165 250);
-  }
-
-  hr {
-    border-color: rgba(255, 255, 255, 0.1);
-  }
+  border-radius: 10px;
+  padding: 12px;
+  overflow: auto;
 }
 
+.prose code {
+  background: #0a0c10;
+  color: #e5e7eb;
+  padding: 3px 6px;
+  border-radius: 6px;
+}
+
+.dark .prose pre,
+.dark .prose code {
+  background: #0b0e16;
+}
+
+/* Minimal utility helpers to preserve layout (not Tailwind generated) */
+.flex { display: flex; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.justify-center { justify-content: center; }
+.gap-1 { gap: 4px; }
+.gap-1\.5 { gap: 6px; }
+.gap-2 { gap: 8px; }
+.gap-3 { gap: 12px; }
+.gap-4 { gap: 16px; }
+.space-y-2 > :not(:last-child) { margin-bottom: 8px; }
+.space-y-3 > :not(:last-child) { margin-bottom: 12px; }
+.space-y-4 > :not(:last-child) { margin-bottom: 16px; }
+.h-10 { height: 40px; }
+.h-14 { height: 56px; }
+.px-4 { padding-left: 16px; padding-right: 16px; }
+.px-6 { padding-left: 24px; padding-right: 24px; }
+.py-2 { padding-top: 8px; padding-bottom: 8px; }
+.py-3 { padding-top: 12px; padding-bottom: 12px; }
+.py-4 { padding-top: 16px; padding-bottom: 16px; }
+.mt-2 { margin-top: 8px; }
+.mt-4 { margin-top: 16px; }
+.mb-1 { margin-bottom: 4px; }
+.mb-2 { margin-bottom: 8px; }
+.mb-3 { margin-bottom: 12px; }
+.mb-4 { margin-bottom: 16px; }
+.rounded-md { border-radius: var(--radius-md); }
+.rounded-xl { border-radius: 20px; }
+.border { border: 1px solid var(--border); }
+.border-b { border-bottom: 1px solid var(--border); }
+.border-t { border-top: 1px solid var(--border); }
+.text-sm { font-size: 14px; }
+.text-xs { font-size: 12px; }
+.font-medium { font-weight: 600; }
+.font-semibold { font-weight: 700; }
+.text-gray-500 { color: var(--text-muted); }
+.text-gray-600 { color: var(--text-muted); }
+.text-gray-900 { color: var(--text); }
+.bg-white { background: var(--bg-raised); }
+.bg-white\/5 { background: color-mix(in srgb, var(--bg-raised) 5%, transparent); }
+.bg-white\/50 { background: color-mix(in srgb, var(--bg-raised) 50%, transparent); }
+.bg-white\/60 { background: color-mix(in srgb, var(--bg-raised) 60%, transparent); }
+.shadow { box-shadow: var(--shadow-soft); }
+.shadow-sm { box-shadow: var(--shadow-soft); }
+.whitespace-pre-wrap { white-space: pre-wrap; }
+.break-words { word-break: break-word; }
+.leading-snug { line-height: 1.4; }
+.uppercase { text-transform: uppercase; }
+.tracking-wide { letter-spacing: 0.04em; }
+.p-2 { padding: 8px; }
+.p-4 { padding: 16px; }
+.px-2 { padding-left: 8px; padding-right: 8px; }
+.py-1 { padding-top: 4px; padding-bottom: 4px; }
+.py-1\.5 { padding-top: 6px; padding-bottom: 6px; }
+.px-2\.5 { padding-left: 10px; padding-right: 10px; }
+.px-3 { padding-left: 12px; padding-right: 12px; }
+.py-2\.5 { padding-top: 10px; padding-bottom: 10px; }
+.w-full { width: 100%; }
+.min-h-\[calc\(100vh-3\.5rem\)\] { min-height: calc(100vh - 56px); }
+.min-h-screen { min-height: 100vh; }
+.min-w-0 { min-width: 0; }
+.grid { display: grid; }
+.grid-cols-12 { grid-template-columns: repeat(12, minmax(0, 1fr)); }
+.col-span-5 { grid-column: span 5 / span 5; }
+.col-span-6 { grid-column: span 6 / span 6; }
+.col-span-1 { grid-column: span 1 / span 1; }
+.list-disc { list-style: disc; }
+.pl-4 { padding-left: 16px; }
+.sticky { position: sticky; }
+.top-0 { top: 0; }
+.rounded-full { border-radius: 999px; }
+.inline-flex { display: inline-flex; }
+.overflow-hidden { overflow: hidden; }
+.whitespace-pre-wrap { white-space: pre-wrap; }
+.break-words { word-wrap: break-word; }
+.max-h-\[360px\] { max-height: 360px; }
+.overflow-y-auto { overflow-y: auto; }


### PR DESCRIPTION
## Summary
- replace Tailwind import with a material-inspired design system using CSS variables, elevations, and reusable layout primitives
- refresh layout wrappers for header, drawers, editor, and modal surfaces to emphasize clean surfaces without glassmorphism
- add progressive disclosure for variables and previews while keeping light/dark theme parity

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692004bff014832b9770bfd07b32673d)